### PR TITLE
Add plugin components and related functionality.

### DIFF
--- a/common/cmake/config.cmake
+++ b/common/cmake/config.cmake
@@ -70,6 +70,7 @@ function(synthclone_initialize_config)
             --function-coverage
             --demangle-cpp
             --erase-functions __cxx_global_var_init
+            --ignore-errors inconsistent
             --directory ${CMAKE_SOURCE_DIR}
             --base-directory ${CMAKE_SOURCE_DIR}
             --gcov-tool "${LLVM_COV}" --gcov-tool gcov

--- a/modules/synthclone.core/src/component.cppm
+++ b/modules/synthclone.core/src/component.cppm
@@ -1,0 +1,176 @@
+/**
+ * @file
+ *
+ * Contains messages used by all components.
+ */
+
+module;
+
+#include <synthclone/config.h>
+
+export module synthclone.core:component;
+
+import std;
+
+import synthclone.util;
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::component_state_changed_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Message type indicating the editor changed a component's state.
+     */
+
+    export
+    struct component_state_changed_message final {};
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::component_progress_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    float
+    verify_component_progress(float n)
+    {
+        verify(
+            (n >= 0.0) && (n <= 1.0), "{0}: invalid component progress value",
+            n);
+        return n;
+    }
+
+    /**
+     * Message indicating the current amount of progress performing an
+     * operation.
+     */
+
+    export
+    class component_progress_message final {
+
+    public:
+
+        /**
+         * Constructs a `component_progress_message` event.
+         *
+         * @param progress
+         *   The progress amount, which should be in the range [0.0, 1.0].
+         */
+
+        constexpr explicit
+        component_progress_message(float progress):
+            progress_(verify_component_progress(progress))
+        {
+            // empty
+        }
+
+        /**
+         * Gets the progress level.
+         *
+         * @return
+         *   The progress level.
+         */
+
+        constexpr
+        float
+        progress()
+        const noexcept
+        {
+            return progress_;
+        }
+
+    private:
+
+        float progress_;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::component_status_string
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * String type that holds the current status of a component operation.
+     */
+
+    export
+    using component_status_string = utf8_line;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::component_status_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Message indicating the current status of an operation.
+     */
+
+    export
+    class component_status_message final {
+
+    public:
+
+        /**
+         * Constructs a `component_status_message` event.
+         *
+         * @param status
+         *   The operation status.
+         */
+
+        constexpr explicit
+        component_status_message(component_status_string status)
+        noexcept:
+            status_(std::move(status))
+        {
+            // empty
+        }
+
+        /**
+         * Gets the status string.
+         *
+         * @return
+         *   The status string.
+         */
+
+        constexpr
+        const component_status_string&
+        status()
+        const noexcept
+        {
+            return status_;
+        }
+
+    private:
+
+        component_status_string status_;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::component_event_wait_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Message type indicating the host should wait for events before resuming
+     * the `edit()` coroutine.
+     */
+
+    export
+    struct component_event_wait_message final {};
+
+}

--- a/modules/synthclone.core/src/component_core.cppm
+++ b/modules/synthclone.core/src/component_core.cppm
@@ -1,0 +1,402 @@
+/**
+ * @file
+ *
+ * Contains base functionality used by all components.
+ */
+
+module;
+
+#include <synthclone/config.h>
+
+export module synthclone.core:component_core;
+
+import std;
+
+import synthclone.util;
+
+import :metadata;
+import :state;
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::component_core_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains core operations for a component type.
+     *
+     * @tparam T
+     *   The base component type.
+     */
+
+    export
+    template<class T>
+    class component_core_ops: private nonmovable {
+
+    public:
+
+        /**
+         * Destructs a `component_core_ops` instance.
+         */
+
+        virtual
+        ~component_core_ops() = default;
+
+        /**
+         * Instantiates a new component instance.
+         *
+         * @return
+         *   A pointer to the new component instance.
+         */
+
+        virtual
+        std::unique_ptr<T>
+        create() = 0;
+
+    protected:
+
+        /**
+         * Constructs a `component_core_ops` instance.
+         */
+
+        explicit
+        component_core_ops() = default;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::component_editor_ops
+///////////////////////////////////////////////////////////////////////////////
+
+class QWindow;
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains component editor operations.
+     *
+     * @tparam T
+     *   The base component type.
+     * @tparam M
+     *   The message variant type.
+     */
+
+    export
+    template<class T, class M>
+    class component_editor_ops: private nonmovable {
+
+    public:
+
+        /**
+         * Destructs a `component_editor_ops` instance.
+         */
+
+        virtual
+        ~component_editor_ops() = default;
+
+        /**
+         * Populates the given window with an editor interface, allowing the
+         * user to edit the component state, and manages the window throughout
+         * the lifetime of the edit operations (e.g. until the window is
+         * closed).
+         *
+         * @param component
+         *   The component to be edited.
+         * @param window
+         *   The window to use to display the edit interface.
+         * @param stop_token
+         *   A stop token that will be set if the operation is cancelled.
+         *
+         * @return
+         *   A generator that is used to send messages back to the host.
+         */
+
+        virtual
+        std::generator<M>
+        edit(T& component, ::QWindow& window, std::stop_token stop_token) = 0;
+
+    protected:
+
+        /**
+         * Constructs a `component_editor_ops` instance.
+         */
+
+        explicit
+        component_editor_ops() = default;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::component_state_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains component state operations.
+     *
+     * @tparam T
+     *   The base component type.
+     */
+
+    export
+    template<class T>
+    class component_state_ops: private nonmovable {
+
+    public:
+
+        /**
+         * Destructs a `component_state_ops` instance.
+         */
+
+        virtual
+        ~component_state_ops() = default;
+
+        /**
+         * Gets a snapshot of the given component's state.
+         *
+         * @param component
+         *   The component to get the state for.
+         *
+         * @return
+         *   The component state.
+         */
+
+        virtual
+        state_value
+        dump(const T& component) = 0;
+
+        /**
+         * Loads a component from the given state.
+         *
+         * @param state
+         *   The state to load the component from.
+         *
+         * @return
+         *   A pointer to the loaded component instance.
+         */
+
+        virtual
+        std::unique_ptr<T>
+        load(const state_value& state) = 0;
+
+    protected:
+
+        /**
+         * Constructs a `component_state_ops` instance.
+         */
+
+        explicit
+        component_state_ops() = default;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::component_type_init_args
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Used to initialize `component_type` instances using aggregate
+     * initialization.
+     *
+     * @tparam C
+     *   The core operations type.
+     * @tparam E
+     *   The edit operations type.
+     * @tparam S
+     *   The state operations type.
+     */
+
+    export
+    template<class C, class E, class S>
+    struct component_type_init_args {
+
+        /**
+         * The component core operations.
+         */
+
+        std::unique_ptr<C> core_ops;
+
+        /**
+         * The component editor operations.
+         */
+
+        std::unique_ptr<E> editor_ops;
+
+        /**
+         * The component state operations.
+         */
+
+        std::unique_ptr<S> state_ops;
+
+        /**
+         * Metadata describing components of the given component type.
+         */
+
+        synthclone::metadata metadata;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::component_type
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    template<class C>
+    constexpr
+    std::unique_ptr<C>&&
+    verify_component_core_ops(std::unique_ptr<C>&& core_ops)
+    {
+        verify(core_ops != nullptr, "`core_ops` cannot be set to null");
+        return std::move(core_ops);
+    }
+
+    template<bool R, class E>
+    constexpr
+    std::unique_ptr<E>&&
+    verify_component_editor_ops(std::unique_ptr<E>&& editor_ops)
+    {
+        if constexpr(R) {
+            verify(
+                editor_ops != nullptr, "`editor_ops` cannot be set to null");
+        }
+        return std::move(editor_ops);
+    }
+
+    /**
+     * Contains operations and metadata corresponding to a specific component
+     * type.
+     *
+     * @tparam C
+     *   The core operations type.
+     * @tparam E
+     *   The edit operations type.
+     * @tparam S
+     *   The state operations type.
+     * @tparam EditorOpsRequired
+     *   Whether or not editor operations are required for the component type.
+     */
+
+    export
+    template<class C, class E, class S, bool EditorOpsRequired = false>
+    class component_type final: private noncopyable {
+
+    public:
+
+        /**
+         * Constructs a `component_type` instance.
+         *
+         * @param args
+         *   The data to use to populate the `component_type` instance.
+         */
+
+        constexpr
+        component_type(component_type_init_args<C, E, S> args):
+            component_type(
+                std::move(args.core_ops), std::move(args.editor_ops),
+                std::move(args.state_ops), std::move(args.metadata))
+        {
+            // empty
+        }
+
+        /**
+         * Gets the core operations for the component type.
+         *
+         * @return
+         *   A pointer to the core operations.
+         */
+
+        constexpr
+        const std::unique_ptr<C>&
+        core_ops()
+        const noexcept
+        {
+            return core_ops_;
+        }
+
+        /**
+         * Gets the (possibly optional) editor operations for the component
+         * type.
+         *
+         * @return
+         *   A pointer to the editor operations.
+         */
+
+        constexpr
+        const std::unique_ptr<E>&
+        editor_ops()
+        const noexcept
+        {
+            return editor_ops_;
+        }
+
+        /**
+         * Gets the metadata corresponding to the component type.
+         *
+         * @return
+         *   The metadata.
+         */
+
+        constexpr
+        const metadata&
+        metadata()
+        const noexcept
+        {
+            return metadata_;
+        }
+
+        /**
+         * Gets the optional state operations for the component type.
+         *
+         * @return
+         *   A pointer to the state operations.
+         */
+
+        constexpr
+        const std::unique_ptr<S>&
+        state_ops()
+        const noexcept
+        {
+            return state_ops_;
+        }
+
+    private:
+
+        constexpr
+        component_type(
+            std::unique_ptr<C>&& core_ops,
+            std::unique_ptr<E>&& editor_ops,
+            std::unique_ptr<S>&& state_ops,
+            class metadata&& metadata
+        ):
+            metadata_(std::move(metadata)),
+            core_ops_(verify_component_core_ops(std::move(core_ops))),
+            editor_ops_(
+                verify_component_editor_ops<EditorOpsRequired>(
+                    std::move(editor_ops))),
+            state_ops_(std::move(state_ops))
+        {
+            // empty
+        }
+
+        class metadata metadata_;
+
+        std::unique_ptr<C> core_ops_;
+        std::unique_ptr<E> editor_ops_;
+        std::unique_ptr<S> state_ops_;
+
+    };
+
+}

--- a/modules/synthclone.core/src/effect.cppm
+++ b/modules/synthclone.core/src/effect.cppm
@@ -1,0 +1,224 @@
+/**
+ * @file
+ *
+ * Contains functionality that allows plugins to create their own effect types.
+ */
+
+module;
+
+#include <synthclone/config.h>
+
+export module synthclone.core:effect;
+
+import std;
+
+import synthclone.util;
+
+import :audio;
+import :component;
+import :component_core;
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::effect_edit_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Variant type containing a message generated during an effect `edit()`
+     * operation.
+     */
+
+    export
+    using effect_edit_message = std::variant<
+        component_event_wait_message,
+        component_state_changed_message
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::effect_run_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Message generated during the process of applying an effect to audio.
+     */
+
+    export
+    using effect_run_message = std::variant<
+        component_progress_message,
+        component_status_message
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::effect_instance
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Effect instance created by a plugin.
+     */
+
+    export
+    class effect_instance: private nonmovable {
+
+    public:
+
+        /**
+         * Destroys an `effect_instance` instance.
+         */
+
+        virtual
+        ~effect_instance() = default;
+
+    protected:
+
+        /**
+         * Constructs an `effect_instance` instance.
+         */
+
+        explicit
+        effect_instance() = default;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::effect_core_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains core operations for an effect type.
+     */
+
+    export
+    class effect_core_ops: public component_core_ops<effect_instance> {
+
+    public:
+
+        /**
+         * Destructs an `effect_core_ops` instance.
+         */
+
+        virtual
+        ~effect_core_ops() = default;
+
+        /**
+         * Applies some transformation to audio in the given input stream and
+         * writes the audio to the given output stream.
+         *
+         * @param instance
+         *   The effect instance.
+         * @param input_stream
+         *   The input stream containing the input audio.
+         * @param output_stream
+         *   The output stream to write audio to.
+         * @param stop_token
+         *   A token to monitor for cancellation.
+         *
+         * @return
+         *   A generator used to emit messages during the process.
+         */
+
+        virtual
+        std::generator<effect_run_message>
+        run(
+            effect_instance& instance,
+            audio_input_stream& input_stream,
+            audio_output_stream& output_stream,
+            std::stop_token stop_token
+        ) = 0;
+
+    protected:
+
+        /**
+         * Constructs an `effect_core_ops` instance.
+         */
+
+        explicit
+        effect_core_ops() = default;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::effect_editor_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains effect editor operations.
+     */
+
+    export
+    using effect_editor_ops = component_editor_ops<
+        effect_instance,
+        effect_edit_message
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::effect_state_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains effect state operations.
+     */
+
+    export
+    using effect_state_ops = component_state_ops<effect_instance>;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::effect_type_init_args
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Used to initialize `effect_type` instances using aggregate
+     * initialization.
+     */
+
+    export
+    using effect_type_init_args = component_type_init_args<
+        effect_core_ops,
+        effect_editor_ops,
+        effect_state_ops
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::effect_type
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains operations and metadata corresponding to an effect type.
+     */
+
+    export
+    using effect_type = component_type<
+        effect_core_ops,
+        effect_editor_ops,
+        effect_state_ops
+    >;
+
+}

--- a/modules/synthclone.core/src/exporter.cppm
+++ b/modules/synthclone.core/src/exporter.cppm
@@ -1,0 +1,239 @@
+/**
+ * @file
+ *
+ * Contains functionality that allows plugins to create their own exporter
+ * types.
+ */
+
+module;
+
+#include <synthclone/config.h>
+
+export module synthclone.core:exporter;
+
+import std;
+
+import synthclone.util;
+
+import :component;
+import :component_core;
+import :zone;
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::exporter_request_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Message indicating the user requested export of the zones in the current
+     * session.
+     */
+
+    export
+    struct exporter_request_message final {};
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::exporter_edit_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Variant type containing a message generated during an exporter `edit()`
+     * operation.
+     */
+
+    export
+    using exporter_edit_message = std::variant<
+        component_event_wait_message,
+        component_state_changed_message,
+        exporter_request_message
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::exporter_run_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Message generated during the process of applying an exporter to audio.
+     */
+
+    export
+    using exporter_run_message = std::variant<
+        component_progress_message,
+        component_status_message
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::exporter_instance
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Exporter instance created by a plugin.
+     */
+
+    export
+    class exporter_instance: private nonmovable {
+
+    public:
+
+        /**
+         * Destroys an `exporter_instance` instance.
+         */
+
+        virtual
+        ~exporter_instance() = default;
+
+    protected:
+
+        /**
+         * Constructs an `exporter_instance` instance.
+         */
+
+        explicit
+        exporter_instance() = default;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::exporter_core_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains core operations for an exporter type.
+     */
+
+    export
+    class exporter_core_ops: public component_core_ops<exporter_instance> {
+
+    public:
+
+        /**
+         * Destructs an `exporter_core_ops` instance.
+         */
+
+        virtual
+        ~exporter_core_ops() = default;
+
+        /**
+         * Exports the given zone data.
+         *
+         * @param instance
+         *   The exporter instance.
+         * @param zones
+         *   A generated range of zones to export.
+         * @param stop_token
+         *   A token to monitor for cancellation.
+         *
+         * @return
+         *   A generator used to emit messages during the process.
+         */
+
+        virtual
+        std::generator<exporter_run_message>
+        run(
+            exporter_instance& instance,
+            std::generator<zone_port_params>& zones,
+            std::stop_token stop_token
+        ) = 0;
+
+    protected:
+
+        /**
+         * Constructs an `exporter_core_ops` instance.
+         */
+
+        explicit
+        exporter_core_ops() = default;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::exporter_editor_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains exporter editor operations.
+     */
+
+    export
+    using exporter_editor_ops = component_editor_ops<
+        exporter_instance,
+        exporter_edit_message
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::exporter_state_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains exporter state operations.
+     */
+
+    export
+    using exporter_state_ops = component_state_ops<exporter_instance>;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::exporter_type_init_args
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Used to initialize `exporter_type` instances using aggregate
+     * initialization.
+     */
+
+    export
+    using exporter_type_init_args = component_type_init_args<
+        exporter_core_ops,
+        exporter_editor_ops,
+        exporter_state_ops
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::exporter_type
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains operations and metadata corresponding to an exporter type.
+     */
+
+    export
+    using exporter_type = component_type<
+        exporter_core_ops,
+        exporter_editor_ops,
+        exporter_state_ops,
+        true
+    >;
+
+}

--- a/modules/synthclone.core/src/importer.cppm
+++ b/modules/synthclone.core/src/importer.cppm
@@ -1,0 +1,286 @@
+/**
+ * @file
+ *
+ * Contains functionality that allows plugins to create their own importer
+ * types.
+ */
+
+module;
+
+#include <synthclone/config.h>
+
+export module synthclone.core:importer;
+
+import std;
+
+import synthclone.util;
+
+import :component;
+import :component_core;
+import :zone;
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::importer_request_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Message indicating the user requested import of zones.
+     */
+
+    export
+    struct importer_request_message final {};
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::importer_edit_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Variant type containing a message generated during an importer `edit()`
+     * operation.
+     */
+
+    export
+    using importer_edit_message = std::variant<
+        component_event_wait_message,
+        component_state_changed_message,
+        importer_request_message
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::importer_zone_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Message indicating that a zone should be generated from the contained
+     * parameters.
+     */
+
+    export
+    class importer_zone_message final: private noncopyable {
+
+    public:
+
+        /**
+         * Constructs an `importer_zone_message` instance.
+         *
+         * @param params
+         *   The zone parameters to use to construct the zone.
+         */
+
+        constexpr explicit
+        importer_zone_message(zone_port_params&& params):
+            params_(std::move(params))
+        {
+            // empty
+        }
+
+        /**
+         * Gets the zone parameters.
+         *
+         * @return
+         *   The zone parameters.
+         */
+
+        constexpr
+        zone_port_params&
+        params()
+        noexcept
+        {
+            return params_;
+        }
+
+    private:
+
+        zone_port_params params_;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::importer_run_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Message generated during the process of importing zones.
+     */
+
+    export
+    using importer_run_message = std::variant<
+        component_progress_message,
+        component_status_message,
+        importer_zone_message
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::importer_instance
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Importer instance created by a plugin.
+     */
+
+    export
+    class importer_instance: private nonmovable {
+
+    public:
+
+        /**
+         * Destroys an `importer_instance` instance.
+         */
+
+        virtual
+        ~importer_instance() = default;
+
+    protected:
+
+        /**
+         * Constructs an `importer_instance` instance.
+         */
+
+        explicit
+        importer_instance() = default;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::importer_core_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains core operations for an importer type.
+     */
+
+    export
+    class importer_core_ops: public component_core_ops<importer_instance> {
+
+    public:
+
+        /**
+         * Destructs an `importer_core_ops` instance.
+         */
+
+        virtual
+        ~importer_core_ops() = default;
+
+        /**
+         * Imports zone data.
+         *
+         * @param instance
+         *   The importer instance.
+         * @param stop_token
+         *   A token to monitor for cancellation.
+         *
+         * @return
+         *   A generator used to emit messages during the process.
+         */
+
+        virtual
+        std::generator<importer_run_message>
+        run(importer_instance& instance, std::stop_token stop_token) = 0;
+
+    protected:
+
+        /**
+         * Constructs an `importer_core_ops` instance.
+         */
+
+        explicit
+        importer_core_ops() = default;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::importer_editor_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains importer editor operations.
+     */
+
+    export
+    using importer_editor_ops = component_editor_ops<
+        importer_instance,
+        importer_edit_message
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::importer_state_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains importer state operations.
+     */
+
+    export
+    using importer_state_ops = component_state_ops<importer_instance>;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::importer_type_init_args
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Used to initialize `importer_type` instances using aggregate
+     * initialization.
+     */
+
+    export
+    using importer_type_init_args = component_type_init_args<
+        importer_core_ops,
+        importer_editor_ops,
+        importer_state_ops
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::importer_type
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains operations and metadata corresponding to an importer type.
+     */
+
+    export
+    using importer_type = component_type<
+        importer_core_ops,
+        importer_editor_ops,
+        importer_state_ops,
+        true
+    >;
+
+}

--- a/modules/synthclone.core/src/metadata.cppm
+++ b/modules/synthclone.core/src/metadata.cppm
@@ -60,45 +60,6 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
 
 namespace SYNTHCLONE_LIB_NAMESPACE {
 
-    constexpr char32_t line_feed = '\n';
-    constexpr char32_t vertical_tab = '\v';
-    constexpr char32_t form_feed = '\f';
-    constexpr char32_t carriage_return = '\r';
-    constexpr char32_t next_line = U'\U00000085';
-    constexpr char32_t line_separator = U'\U00002028';
-    constexpr char32_t paragraph_separator = U'\U00002029';
-
-    std::string&&
-    verify_metadata_element(std::string&& s)
-    {
-        if (s.empty()) [[unlikely]] {
-            throw metadata_error("metadata element strings cannot be empty");
-        }
-        std::ranges::for_each(
-            decode_utf8(std::as_bytes(std::span(s))),
-            [](const unicode_codepoint c) {
-                switch (c.value()) {
-                case line_feed:
-                case vertical_tab:
-                case form_feed:
-                case carriage_return:
-                case next_line:
-                case line_separator:
-                case paragraph_separator:
-                    throw metadata_error(
-                        std::format(
-                            "codepoint {0} must not be present in a metadata "
-                            "element",
-                            static_cast<std::uint_least32_t>(c)));
-
-                [[likely]] default:
-                    ;
-                }
-            });
-
-        return std::move(s);
-    }
-
     /**
      * A metadata string type that can hold any UTF-8 encoded data except line
      * terminators.
@@ -107,37 +68,7 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
      */
 
     export
-    class metadata_element final: public string_proxy<metadata_element> {
-
-    public:
-
-        /**
-         * Constructs a `metadata_element` instance.
-         *
-         * @param args
-         *   The arguments to pass to the `std::string` constructor.
-         */
-
-        template<class... Args>
-        requires (std::constructible_from<std::string, Args...>)
-        explicit (
-            (sizeof...(Args) != 1) ||
-            (
-                ! implicitly_convertible_to<
-                    boost::mp11::mp_front<boost::mp11::mp_list<Args...>>,
-                    std::string
-                >
-            )
-        )
-        metadata_element(Args&&... args):
-            string_proxy<metadata_element>(
-                verify_metadata_element(
-                    std::string(std::forward<Args>(args)...)))
-        {
-            // empty
-        }
-
-    };
+    using metadata_element = utf8_line;
 
 }
 

--- a/modules/synthclone.core/src/midi.cppm
+++ b/modules/synthclone.core/src/midi.cppm
@@ -17,6 +17,8 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
 
     export using synthclone::midi_aftertouch;
     export using synthclone::midi_channel;
+    export using synthclone::midi_channel_pressure;
+    export using synthclone::midi_control_array;
     export using synthclone::midi_control_index;
     export using synthclone::midi_control_type;
     export using synthclone::midi_control_value;

--- a/modules/synthclone.core/src/midi_core.cppm
+++ b/modules/synthclone.core/src/midi_core.cppm
@@ -105,6 +105,49 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// synthclone::midi_channel_pressure
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    constexpr
+    std::uint_least8_t
+    verify_midi_channel_pressure(const std::uint_least8_t n)
+    {
+        verify(n <= 127, "{0}: invalid MIDI channel pressure value", n);
+        return n;
+    }
+
+    /**
+     * Contains a valid MIDI channel pressure value.
+     */
+
+    export
+    class midi_channel_pressure final:
+        public uint_least8_proxy<midi_channel_pressure> {
+
+    public:
+
+        /**
+         * Constructs a `midi_channel_pressure` instance.
+         *
+         * @param n
+         *   The MIDI channel pressure value.
+         */
+
+        constexpr
+        midi_channel_pressure(const std::uint_least8_t n):
+            uint_least8_proxy<midi_channel_pressure>(
+                verify_midi_channel_pressure(n))
+        {
+            // empty
+        }
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // synthclone::midi_control_index
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -240,6 +283,23 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
         }
 
     };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::midi_control_array
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Array type that holds optional control values for each of the 128
+     * control indices.
+     */
+
+    export
+    using midi_control_array =
+        std::array<std::optional<midi_control_value>, 128>;
 
 }
 

--- a/modules/synthclone.core/src/module.cppm
+++ b/modules/synthclone.core/src/module.cppm
@@ -7,6 +7,12 @@
 export module synthclone.core;
 
 export import :audio;
+export import :component;
+export import :effect;
+export import :exporter;
+export import :importer;
 export import :metadata;
 export import :midi;
+export import :sampler;
 export import :state;
+export import :zone;

--- a/modules/synthclone.core/src/sampler.cppm
+++ b/modules/synthclone.core/src/sampler.cppm
@@ -1,0 +1,264 @@
+/**
+ * @file
+ *
+ * Contains functionality that allows plugins to create their own sampler
+ * types.
+ */
+
+module;
+
+#include <synthclone/config.h>
+
+export module synthclone.core:sampler;
+
+import std;
+
+import synthclone.util;
+
+import :audio;
+import :component;
+import :component_core;
+import :midi;
+import :zone;
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::sampler_edit_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Variant type containing a message generated during a sampler `edit()`
+     * operation.
+     */
+
+    export
+    using sampler_edit_message = std::variant<
+        component_event_wait_message,
+        component_state_changed_message
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::sampler_capture_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Message generated during the process of capturing audio.
+     */
+
+    export
+    using sampler_capture_message = std::variant<
+        component_progress_message,
+        component_status_message
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::sampler_play_message
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Message generated during the process of playing audio.
+     */
+
+    export
+    using sampler_play_message = std::variant<
+        component_progress_message,
+        component_status_message
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::sampler_instance
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Sampler instance created by a plugin.
+     */
+
+    export
+    class sampler_instance: private nonmovable {
+
+    public:
+
+        /**
+         * Destroys a `sampler_instance` instance.
+         */
+
+        virtual
+        ~sampler_instance() = default;
+
+    protected:
+
+        /**
+         * Constructs a `sampler_instance` instance.
+         */
+
+        explicit
+        sampler_instance() = default;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::sampler_core_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains core operations for a sampler type.
+     */
+
+    export
+    class sampler_core_ops: public component_core_ops<sampler_instance> {
+
+    public:
+
+        /**
+         * Destructs a `sampler_core_ops` instance.
+         */
+
+        virtual
+        ~sampler_core_ops() = default;
+
+        /**
+         * Captures audio corresponding to the given capture parameters.
+         *
+         * @param instance
+         *   The sampler instance.
+         * @param capture_params
+         *   The sample capture parameters.
+         * @param output_stream
+         *   The output stream to which the captured audio should be written.
+         * @param stop_token
+         *   A token to monitor for cancellation.
+         *
+         * @return
+         *   A generator used to emit messages during the process.
+         */
+
+        virtual std::generator<sampler_capture_message>
+        capture(
+            sampler_instance& instance,
+            const zone_capture_params& capture_params,
+            audio_output_stream& output_stream,
+            std::stop_token stop_token
+        ) = 0;
+
+        /**
+         * Plays audio from the given audio input stream.
+         *
+         * @param instance
+         *   The sampler instance.
+         * @param input_stream
+         *   The input stream containing the audio to play.
+         * @param stop_token
+         *   A token to monitor for cancellation.
+         *
+         * @return
+         *   A generator used to emit messages during the process.
+         */
+
+        virtual std::generator<sampler_play_message>
+        play(
+            sampler_instance& instance,
+            audio_input_stream& input_stream,
+            std::stop_token stop_token
+        ) = 0;
+
+    protected:
+
+        /**
+         * Constructs a `sampler_core_ops` instance.
+         */
+
+        explicit
+        sampler_core_ops() = default;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::sampler_editor_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains sampler editor operations.
+     */
+
+    export
+    using sampler_editor_ops = component_editor_ops<
+        sampler_instance,
+        sampler_edit_message
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::sampler_state_ops
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains sampler state operations.
+     */
+
+    export
+    using sampler_state_ops = component_state_ops<sampler_instance>;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::sampler_type_init_args
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Used to initialize `sampler_type` instances using aggregate
+     * initialization.
+     */
+
+    export
+    using sampler_type_init_args = component_type_init_args<
+        sampler_core_ops,
+        sampler_editor_ops,
+        sampler_state_ops
+    >;
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::sampler_type
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains operations and metadata corresponding to a sampler type.
+     */
+
+    export
+    using sampler_type = component_type<
+        sampler_core_ops,
+        sampler_editor_ops,
+        sampler_state_ops
+    >;
+
+}

--- a/modules/synthclone.core/src/zone.cppm
+++ b/modules/synthclone.core/src/zone.cppm
@@ -1,0 +1,491 @@
+/**
+ * @file
+ *
+ * Contains portions of zone data needed by components during component
+ * operations.
+ */
+
+module;
+
+#include <synthclone/config.h>
+
+export module synthclone.core:zone;
+
+import std;
+
+import synthclone.util;
+
+import :audio;
+import :midi;
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::zone_capture_params_init_args
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Used to initialize `zone_capture_params` instances using aggregate
+     * initialization.
+     */
+
+    export
+    struct zone_capture_params_init_args final {
+
+        /**
+         * The MIDI channel.
+         */
+
+        midi_channel channel;
+
+        /**
+         * The MIDI note.
+         */
+
+        midi_note note;
+
+        /**
+         * The MIDI velocity.
+         */
+
+        midi_velocity velocity;
+
+        /**
+         * The optional MIDI aftertouch value.
+         */
+
+        std::optional<midi_aftertouch> aftertouch;
+
+        /**
+         * The optional MIDI channel pressure value.
+         */
+
+        std::optional<midi_channel_pressure> channel_pressure;
+
+        /**
+         * The optional MIDI control values.
+         */
+
+        midi_control_array controls;
+
+        /**
+         * The time the sampler should spend (or spent) capturing audio after
+         * the MIDI parameter are (or were) sent.
+         */
+
+        audio_duration sample_duration;
+
+        /**
+         * The additional time the sampler should spend (or spent) capturing
+         * audio after the MIDI note off event is (or was) sent.
+         */
+
+        audio_duration release_duration;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::zone_capture_params
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains data used by the sampler to capture an audio sample.
+     */
+
+    export
+    class zone_capture_params final {
+
+    public:
+
+        /**
+         * Constructs a `zone_capture_params` instance using the given
+         * arguments.
+         *
+         * @params args
+         *   The arguments to use.
+         */
+
+        constexpr
+        zone_capture_params(const zone_capture_params_init_args& args)
+        noexcept:
+            controls_(args.controls),
+            sample_duration_(args.sample_duration),
+            release_duration_(args.release_duration),
+            aftertouch_(args.aftertouch),
+            channel_pressure_(args.channel_pressure),
+            channel_(args.channel),
+            note_(args.note),
+            velocity_(args.velocity)
+        {
+            // empty
+        }
+
+        /**
+         * Gets the optional MIDI aftertouch value.
+         *
+         * @returns
+         *   The aftertouch value.
+         */
+
+        constexpr
+        std::optional<midi_aftertouch>
+        aftertouch()
+        const noexcept
+        {
+            return aftertouch_;
+        }
+
+        /**
+         * Gets the MIDI channel.
+         *
+         * @returns
+         *   The MIDI channel.
+         */
+
+        constexpr
+        midi_channel
+        channel()
+        const noexcept
+        {
+            return channel_;
+        }
+
+        /**
+         * Gets the optional MIDI channel pressure value.
+         *
+         * @returns
+         *   The pressure value.
+         */
+
+        constexpr
+        std::optional<midi_channel_pressure>
+        channel_pressure()
+        const noexcept
+        {
+            return channel_pressure_;
+        }
+
+        /**
+         * Gets the MIDI control values.
+         *
+         * @returns
+         *   The control values.
+         */
+
+        constexpr
+        const midi_control_array&
+        controls()
+        const noexcept
+        {
+            return controls_;
+        }
+
+        /**
+         * Gets the MIDI note value.
+         *
+         * @returns
+         *   The note value.
+         */
+
+        constexpr
+        midi_note
+        note()
+        const noexcept
+        {
+            return note_;
+        }
+
+        /**
+         * Gets the release duration.
+         *
+         * @returns
+         *   The release duration.
+         */
+
+        constexpr
+        audio_duration
+        release_duration()
+        const noexcept
+        {
+            return release_duration_;
+        }
+
+        /**
+         * Gets the sample duration.
+         *
+         * @returns
+         *   The sample duration.
+         */
+
+        constexpr
+        audio_duration
+        sample_duration()
+        const noexcept
+        {
+            return sample_duration_;
+        }
+
+        /**
+         * Gets the MIDI velocity.
+         *
+         * @returns
+         *   The MIDI velocity.
+         */
+
+        constexpr
+        midi_velocity
+        velocity()
+        const noexcept
+        {
+            return velocity_;
+        }
+
+    private:
+
+        midi_control_array controls_;
+
+        audio_duration sample_duration_;
+        audio_duration release_duration_;
+
+        std::optional<midi_aftertouch> aftertouch_;
+        std::optional<midi_channel_pressure> channel_pressure_;
+
+        midi_channel channel_;
+        midi_note note_;
+        midi_velocity velocity_;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::zone_port_params_init_args
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Used to initialize `zone_port_params` instances using aggregate
+     * initialization.
+     */
+
+    export
+    struct zone_port_params_init_args final {
+
+        /**
+         * The MIDI channel.
+         */
+
+        midi_channel channel;
+
+        /**
+         * The MIDI note.
+         */
+
+        midi_note note;
+
+        /**
+         * The MIDI velocity.
+         */
+
+        midi_velocity velocity;
+
+        /**
+         * The optional MIDI aftertouch value.
+         */
+
+        std::optional<midi_aftertouch> aftertouch;
+
+        /**
+         * The optional MIDI channel pressure value.
+         */
+
+        std::optional<midi_channel_pressure> channel_pressure;
+
+        /**
+         * The optional MIDI control values.
+         */
+
+        midi_control_array controls;
+
+        /**
+         * An optional audio input stream referencing the sample associated
+         * with the zone.
+         */
+
+        std::optional<audio_input_stream> input_stream;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::zone_port_params
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    std::optional<audio_input_stream>&&
+    verify_zone_port_input_stream(std::optional<audio_input_stream>&& stream)
+    {
+        verify(
+            ! (stream && stream->closed()),
+            "the given audio input stream is closed");
+        return std::move(stream);
+    }
+
+    /**
+     * Contains data used by importers and exporters to import/export a zone.
+     */
+
+    export
+    class zone_port_params final: private noncopyable {
+
+    public:
+
+        /**
+         * Constructs a `zone_port_params` instance using the given arguments.
+         *
+         * @params args
+         *   The arguments to use.
+         */
+
+        inline
+        zone_port_params(zone_port_params_init_args args):
+            controls_(args.controls),
+            input_stream_(
+                verify_zone_port_input_stream(std::move(args.input_stream))),
+            aftertouch_(args.aftertouch),
+            channel_pressure_(args.channel_pressure),
+            channel_(args.channel),
+            note_(args.note),
+            velocity_(args.velocity)
+        {
+            // empty
+        }
+
+        /**
+         * Gets the optional MIDI aftertouch value.
+         *
+         * @returns
+         *   The aftertouch value.
+         */
+
+        constexpr
+        std::optional<midi_aftertouch>
+        aftertouch()
+        const noexcept
+        {
+            return aftertouch_;
+        }
+
+        /**
+         * Gets the MIDI channel.
+         *
+         * @returns
+         *   The MIDI channel.
+         */
+
+        constexpr
+        midi_channel
+        channel()
+        const noexcept
+        {
+            return channel_;
+        }
+
+        /**
+         * Gets the optional MIDI channel pressure value.
+         *
+         * @returns
+         *   The pressure value.
+         */
+
+        constexpr
+        std::optional<midi_channel_pressure>
+        channel_pressure()
+        const noexcept
+        {
+            return channel_pressure_;
+        }
+
+        /**
+         * Gets the MIDI control values.
+         *
+         * @returns
+         *   The control values.
+         */
+
+        constexpr
+        const midi_control_array&
+        controls()
+        const noexcept
+        {
+            return controls_;
+        }
+
+        /**
+         * Gets the optional input stream associated with the zone.
+         *
+         * @return
+         *   The input stream.
+         */
+
+        constexpr
+        std::optional<audio_input_stream>&
+        input_stream()
+        noexcept
+        {
+            return input_stream_;
+        }
+
+        /**
+         * Gets the MIDI note value.
+         *
+         * @returns
+         *   The note value.
+         */
+
+        constexpr
+        midi_note
+        note()
+        const noexcept
+        {
+            return note_;
+        }
+
+        /**
+         * Gets the MIDI velocity.
+         *
+         * @returns
+         *   The MIDI velocity.
+         */
+
+        constexpr
+        midi_velocity
+        velocity()
+        const noexcept
+        {
+            return velocity_;
+        }
+
+    private:
+
+        midi_control_array controls_;
+
+        std::optional<audio_input_stream> input_stream_;
+
+        std::optional<midi_aftertouch> aftertouch_;
+        std::optional<midi_channel_pressure> channel_pressure_;
+
+        midi_channel channel_;
+        midi_note note_;
+        midi_velocity velocity_;
+
+    };
+
+}

--- a/modules/synthclone.core/tests/audio.cppm
+++ b/modules/synthclone.core/tests/audio.cppm
@@ -7,6 +7,7 @@ export module synthclone.core.tests:audio;
 import std;
 
 import synthclone.core;
+import synthclone.test;
 import synthclone.util;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -41,14 +42,7 @@ namespace synthclone {
     audio_sample_buffer<FrameCount * ChannelCount>
     load_audio(const std::filesystem::path& path)
     {
-        BOOST_TEST_INFO_SCOPE(
-            std::format(
-                "synthclone::load_audio<"
-                "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}"
-                ">({8:?})",
-                get_identifier(Format), get_identifier(Codec),
-                get_identifier(Endianness), SampleRate, ChannelCount,
-                FrameCount, FrameOffset, ExpectEos, path.string()));
+        BOOST_TEST_INFO_SCOPE(make_test_info("synthclone::load_audio", path));
 
         constexpr audio_traits traits(
             Format, Codec, Endianness, SampleRate, ChannelCount);
@@ -111,6 +105,107 @@ namespace synthclone {
         }
 
         return buffer;
+    }
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::verify_audio_traits()
+///////////////////////////////////////////////////////////////////////////////
+
+namespace synthclone {
+
+    export
+    void
+    verify_audio_traits(
+        const audio_traits& traits,
+        audio_format expected_format,
+        audio_codec expected_codec,
+        audio_endianness expected_endianness,
+        audio_sample_rate expected_sample_rate,
+        audio_channel_count expected_channel_count
+    )
+    {
+        BOOST_TEST_INFO_SCOPE(
+            make_test_info(
+                "synthclone::verify_audio_traits", traits,
+                get_identifier(expected_format),
+                get_identifier(expected_codec),
+                get_identifier(expected_endianness), expected_sample_rate,
+                expected_channel_count));
+
+        verify_eq(traits.format(), expected_format);
+        verify_eq(traits.codec(), expected_codec);
+        verify_eq(traits.endianness(), expected_endianness);
+        verify_eq(traits.sample_rate(), expected_sample_rate);
+        verify_eq(traits.channel_count(), expected_channel_count);
+    }
+
+    export
+    void
+    verify_audio_traits(const audio_traits& lhs, const audio_traits& rhs)
+    {
+        BOOST_TEST_INFO_SCOPE(
+            make_test_info("synthclone::verify_audio_traits", lhs, rhs));
+
+        verify_audio_traits(
+            lhs, rhs.format(), rhs.codec(), rhs.endianness(),
+            rhs.sample_rate(), rhs.channel_count());
+
+        verify_eq(lhs, rhs);
+    }
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::verify_audio_input_stream()
+///////////////////////////////////////////////////////////////////////////////
+
+namespace synthclone {
+
+    export
+    void
+    verify_audio_input_stream(audio_input_stream& lhs, audio_input_stream& rhs)
+    {
+        BOOST_TEST_INFO_SCOPE(
+            make_test_info("synthclone::verify_audio_input_stream", lhs, rhs));
+
+        verify_audio_traits(lhs.traits(), rhs.traits());
+
+        auto closed = lhs.closed();
+        verify_eq(closed, rhs.closed());
+
+        if (closed) {
+            return;
+        }
+
+        auto seekable = lhs.seekable();
+        verify_eq(seekable, rhs.seekable());
+
+        if (seekable) {
+            verify_eq(lhs.tell(), rhs.tell());
+        }
+
+        std::array<audio_sample, 4096> lhs_buffer;
+        std::array<audio_sample, 4096> rhs_buffer;
+
+        for (;;) {
+
+            const auto lhs_read_count = lhs.read(lhs_buffer);
+            const auto rhs_read_count = rhs.read(rhs_buffer);
+            verify_eq(lhs_read_count, rhs_read_count);
+
+            if (! lhs_read_count) {
+                break;
+            }
+
+            std::span lhs_span(lhs_buffer.data(), lhs_read_count);
+            std::span rhs_span(rhs_buffer.data(), rhs_read_count);
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(
+                lhs_span.begin(), lhs_span.end(), rhs_span.begin(),
+                rhs_span.end());
+        }
     }
 
 }

--- a/modules/synthclone.core/tests/audio_core.cpp
+++ b/modules/synthclone.core/tests/audio_core.cpp
@@ -1,6 +1,7 @@
 #include <boost/test/unit_test.hpp>
 
 import synthclone.core;
+import synthclone.core.tests;
 import synthclone.test;
 import synthclone.util;
 
@@ -15,36 +16,6 @@ namespace {
 
         BOOST_CHECK_THROW(T{Max + 1}, synthclone::verification_error);
         BOOST_CHECK_THROW(T{Min - 1}, synthclone::verification_error);
-    }
-
-    void
-    verify_traits(
-        const synthclone::audio_traits& traits,
-        synthclone::audio_format expected_format,
-        synthclone::audio_codec expected_codec,
-        synthclone::audio_endianness expected_endianness,
-        synthclone::audio_sample_rate expected_sample_rate,
-        synthclone::audio_channel_count expected_channel_count
-    )
-    {
-        synthclone::verify_eq(traits.format(), expected_format);
-        synthclone::verify_eq(traits.codec(), expected_codec);
-        synthclone::verify_eq(traits.endianness(), expected_endianness);
-        synthclone::verify_eq(traits.sample_rate(), expected_sample_rate);
-        synthclone::verify_eq(traits.channel_count(), expected_channel_count);
-    }
-
-    void
-    verify_traits(
-        const synthclone::audio_traits& lhs,
-        const synthclone::audio_traits& rhs
-    )
-    {
-        verify_traits(
-            lhs, rhs.format(), rhs.codec(), rhs.endianness(),
-            rhs.sample_rate(), rhs.channel_count());
-
-        synthclone::verify_eq(lhs, rhs);
     }
 
 }
@@ -97,7 +68,7 @@ BOOST_AUTO_TEST_CASE(traits)
         synthclone::audio_format::wav, synthclone::audio_codec::pcm_s16,
         16000U, 2U);
 
-    verify_traits(
+    synthclone::verify_audio_traits(
         traits_1, synthclone::audio_format::wav,
         synthclone::audio_codec::pcm_s16, synthclone::audio_endianness::file,
         16000U, 2U);
@@ -106,21 +77,21 @@ BOOST_AUTO_TEST_CASE(traits)
         synthclone::audio_format::raw, synthclone::audio_codec::pcm_f64,
         synthclone::audio_endianness::big, 44100U, 1U);
 
-    verify_traits(
+    synthclone::verify_audio_traits(
         traits_2, synthclone::audio_format::raw,
         synthclone::audio_codec::pcm_f64, synthclone::audio_endianness::big,
         44100U, 1U);
 
     synthclone::audio_traits traits_3(traits_1);
 
-    verify_traits(
+    synthclone::verify_audio_traits(
         traits_3, synthclone::audio_format::wav,
         synthclone::audio_codec::pcm_s16, synthclone::audio_endianness::file,
         16000U, 2U);
 
     traits_1 = traits_2;
 
-    verify_traits(
+    synthclone::verify_audio_traits(
         traits_1, synthclone::audio_format::raw,
         synthclone::audio_codec::pcm_f64, synthclone::audio_endianness::big,
         44100U, 1U);

--- a/modules/synthclone.core/tests/audio_io.cpp
+++ b/modules/synthclone.core/tests/audio_io.cpp
@@ -1,8 +1,7 @@
-#include <filesystem>
-
 #include <boost/interprocess/mapped_region.hpp>
-
 #include <boost/test/unit_test.hpp>
+
+import std;
 
 import synthclone.core;
 import synthclone.core.tests;

--- a/modules/synthclone.core/tests/component.cpp
+++ b/modules/synthclone.core/tests/component.cpp
@@ -1,0 +1,54 @@
+#include <boost/test/unit_test.hpp>
+
+import std;
+
+import synthclone.core;
+import synthclone.test;
+import synthclone.util;
+
+BOOST_AUTO_TEST_SUITE(component)
+
+BOOST_AUTO_TEST_CASE(progress_message)
+{
+    synthclone::component_progress_message message_1(0.5);
+    synthclone::verify_eq(0.5, message_1.progress());
+
+    synthclone::component_progress_message message_2(0.75);
+    synthclone::verify_eq(0.75, message_2.progress());
+
+    synthclone::component_progress_message message_3(message_1);
+    synthclone::verify_eq(0.5, message_3.progress());
+
+    message_1 = message_2;
+    synthclone::verify_eq(0.75, message_1.progress());
+
+    BOOST_CHECK_THROW(
+        synthclone::component_progress_message(1.1),
+        synthclone::verification_error);
+    BOOST_CHECK_THROW(
+        synthclone::component_progress_message(-0.1),
+        synthclone::verification_error);
+}
+
+BOOST_AUTO_TEST_CASE(status_message)
+{
+    synthclone::component_status_message message_1("foo");
+    synthclone::verify_eq("foo", message_1.status());
+
+    synthclone::component_status_message message_2("bar");
+    synthclone::verify_eq("bar", message_2.status());
+
+    synthclone::component_status_message message_3(message_1);
+    synthclone::verify_eq("foo", message_3.status());
+
+    synthclone::component_status_message message_4(std::move(message_1));
+    synthclone::verify_eq("foo", message_4.status());
+
+    message_1 = message_2;
+    synthclone::verify_eq("bar", message_1.status());
+
+    message_2 = std::move(message_3);
+    synthclone::verify_eq("foo", message_2.status());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/modules/synthclone.core/tests/effect.cpp
+++ b/modules/synthclone.core/tests/effect.cpp
@@ -1,0 +1,158 @@
+#include <boost/test/unit_test.hpp>
+
+import std;
+
+import synthclone.core;
+import synthclone.test;
+import synthclone.util;
+
+class QWindow;
+
+namespace {
+
+    class test_core_ops final: public synthclone::effect_core_ops {
+
+    public:
+
+        std::unique_ptr<synthclone::effect_instance>
+        create()
+        override final
+        {
+            return nullptr;
+        }
+
+        std::generator<synthclone::effect_run_message>
+        run(
+            synthclone::effect_instance& instance,
+            synthclone::audio_input_stream& input_stream,
+            synthclone::audio_output_stream& output_stream,
+            std::stop_token stop_token
+        )
+        override final
+        {
+            co_return;
+        }
+
+    };
+
+    class test_editor_ops final: public synthclone::effect_editor_ops {
+
+    public:
+
+        std::generator<synthclone::effect_edit_message>
+        edit(
+            synthclone::effect_instance& instance,
+            ::QWindow& window,
+            std::stop_token stop_token
+        )
+        override final
+        {
+            co_return;
+        }
+
+    };
+
+    class test_instance final: public synthclone::effect_instance {};
+
+    class test_state_ops final: public synthclone::effect_state_ops {
+
+    public:
+
+        synthclone::state_value
+        dump(const synthclone::effect_instance& instance)
+        override final
+        {
+            return synthclone::state_value();
+        }
+
+        std::unique_ptr<synthclone::effect_instance>
+        load(const synthclone::state_value& value)
+        override final
+        {
+            return nullptr;
+        }
+
+    };
+
+    void
+    verify_type(
+        const synthclone::effect_type& type,
+        const synthclone::effect_core_ops* expected_core_ops_ptr,
+        const synthclone::effect_editor_ops* expected_editor_ops_ptr,
+        const synthclone::effect_state_ops* expected_state_ops_ptr,
+        const synthclone::metadata& expected_metadata
+    )
+    {
+        synthclone::verify_eq(expected_core_ops_ptr, type.core_ops().get());
+        synthclone::verify_eq(
+            expected_editor_ops_ptr, type.editor_ops().get());
+        synthclone::verify_eq(expected_state_ops_ptr, type.state_ops().get());
+        synthclone::verify_eq(expected_metadata, type.metadata());
+    }
+
+}
+
+BOOST_AUTO_TEST_SUITE(effect)
+
+BOOST_AUTO_TEST_CASE(instance)
+{
+    std::unique_ptr<synthclone::effect_instance> instance(
+        std::make_unique<test_instance>());
+    instance.reset();
+}
+
+BOOST_AUTO_TEST_CASE(types)
+{
+    auto core_ops_1 = std::make_unique<test_core_ops>();
+    const auto* core_ops_1_ptr = core_ops_1.get();
+    synthclone::metadata metadata_1(
+        {
+            .identifier = "foo",
+            .version = "1.2.3"
+        });
+    synthclone::effect_type type_1(
+        {
+            .core_ops = std::move(core_ops_1),
+            .metadata = metadata_1
+        });
+    verify_type(type_1, core_ops_1_ptr, nullptr, nullptr, metadata_1);
+
+    auto core_ops_2 = std::make_unique<test_core_ops>();
+    const auto* core_ops_2_ptr = core_ops_2.get();
+    auto editor_ops_2 = std::make_unique<test_editor_ops>();
+    const auto* editor_ops_2_ptr = editor_ops_2.get();
+    auto state_ops_2 = std::make_unique<test_state_ops>();
+    const auto* state_ops_2_ptr = state_ops_2.get();
+
+    synthclone::metadata metadata_2(
+        {
+            .identifier = "bar",
+            .version = "4.5.6"
+        });
+    synthclone::effect_type type_2(
+        {
+            .core_ops = std::move(core_ops_2),
+            .editor_ops = std::move(editor_ops_2),
+            .state_ops = std::move(state_ops_2),
+            .metadata = metadata_2
+        });
+    verify_type(
+        type_2, core_ops_2_ptr, editor_ops_2_ptr, state_ops_2_ptr, metadata_2);
+
+    synthclone::effect_type type_3 = std::move(type_1);
+    verify_type(type_3, core_ops_1_ptr, nullptr, nullptr, metadata_1);
+
+    type_1 = std::move(type_2);
+    verify_type(
+        type_1, core_ops_2_ptr, editor_ops_2_ptr, state_ops_2_ptr, metadata_2);
+
+    BOOST_CHECK_THROW(
+        synthclone::effect_type(
+            {
+                .core_ops = nullptr,
+                .metadata = metadata_1
+            }),
+        synthclone::verification_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/modules/synthclone.core/tests/exporter.cpp
+++ b/modules/synthclone.core/tests/exporter.cpp
@@ -1,0 +1,167 @@
+#include <boost/test/unit_test.hpp>
+
+import std;
+
+import synthclone.core;
+import synthclone.test;
+import synthclone.util;
+
+class QWindow;
+
+namespace {
+
+    class test_core_ops final: public synthclone::exporter_core_ops {
+
+    public:
+
+        std::unique_ptr<synthclone::exporter_instance>
+        create()
+        override final
+        {
+            return nullptr;
+        }
+
+        std::generator<synthclone::exporter_run_message>
+        run(
+            synthclone::exporter_instance& instance,
+            std::generator<synthclone::zone_port_params>& zones,
+            std::stop_token stop_token
+        )
+        override final
+        {
+            co_return;
+        }
+
+    };
+
+    class test_editor_ops final: public synthclone::exporter_editor_ops {
+
+    public:
+
+        std::generator<synthclone::exporter_edit_message>
+        edit(
+            synthclone::exporter_instance& instance,
+            ::QWindow& window,
+            std::stop_token stop_token
+        )
+        override final
+        {
+            co_return;
+        }
+
+    };
+
+    class test_instance final: public synthclone::exporter_instance {};
+
+    class test_state_ops final: public synthclone::exporter_state_ops {
+
+    public:
+
+        synthclone::state_value
+        dump(const synthclone::exporter_instance& instance)
+        override final
+        {
+            return synthclone::state_value();
+        }
+
+        std::unique_ptr<synthclone::exporter_instance>
+        load(const synthclone::state_value& value)
+        override final
+        {
+            return nullptr;
+        }
+
+    };
+
+    void
+    verify_type(
+        const synthclone::exporter_type& type,
+        const synthclone::exporter_core_ops* expected_core_ops_ptr,
+        const synthclone::exporter_editor_ops* expected_editor_ops_ptr,
+        const synthclone::exporter_state_ops* expected_state_ops_ptr,
+        const synthclone::metadata& expected_metadata
+    )
+    {
+        synthclone::verify_eq(expected_core_ops_ptr, type.core_ops().get());
+        synthclone::verify_eq(
+            expected_editor_ops_ptr, type.editor_ops().get());
+        synthclone::verify_eq(expected_state_ops_ptr, type.state_ops().get());
+        synthclone::verify_eq(expected_metadata, type.metadata());
+    }
+
+}
+
+BOOST_AUTO_TEST_SUITE(exporter)
+
+BOOST_AUTO_TEST_CASE(instance)
+{
+    std::unique_ptr<synthclone::exporter_instance> instance(
+        std::make_unique<test_instance>());
+    instance.reset();
+}
+
+BOOST_AUTO_TEST_CASE(types)
+{
+    auto core_ops_1 = std::make_unique<test_core_ops>();
+    const auto* core_ops_1_ptr = core_ops_1.get();
+    auto editor_ops_1 = std::make_unique<test_editor_ops>();
+    const auto* editor_ops_1_ptr = editor_ops_1.get();
+    synthclone::metadata metadata_1(
+        {
+            .identifier = "foo",
+            .version = "1.2.3"
+        });
+    synthclone::exporter_type type_1(
+        {
+            .core_ops = std::move(core_ops_1),
+            .editor_ops = std::move(editor_ops_1),
+            .metadata = metadata_1
+        });
+    verify_type(type_1, core_ops_1_ptr, editor_ops_1_ptr, nullptr, metadata_1);
+
+    auto core_ops_2 = std::make_unique<test_core_ops>();
+    const auto* core_ops_2_ptr = core_ops_2.get();
+    auto editor_ops_2 = std::make_unique<test_editor_ops>();
+    const auto* editor_ops_2_ptr = editor_ops_2.get();
+    auto state_ops_2 = std::make_unique<test_state_ops>();
+    const auto* state_ops_2_ptr = state_ops_2.get();
+
+    synthclone::metadata metadata_2(
+        {
+            .identifier = "bar",
+            .version = "4.5.6"
+        });
+    synthclone::exporter_type type_2(
+        {
+            .core_ops = std::move(core_ops_2),
+            .editor_ops = std::move(editor_ops_2),
+            .state_ops = std::move(state_ops_2),
+            .metadata = metadata_2
+        });
+    verify_type(
+        type_2, core_ops_2_ptr, editor_ops_2_ptr, state_ops_2_ptr, metadata_2);
+
+    synthclone::exporter_type type_3 = std::move(type_1);
+    verify_type(type_3, core_ops_1_ptr, editor_ops_1_ptr, nullptr, metadata_1);
+
+    type_1 = std::move(type_2);
+    verify_type(
+        type_1, core_ops_2_ptr, editor_ops_2_ptr, state_ops_2_ptr, metadata_2);
+
+    BOOST_CHECK_THROW(
+        synthclone::exporter_type(
+            {
+                .core_ops = std::make_unique<test_core_ops>(),
+                .metadata = metadata_1
+            }),
+        synthclone::verification_error);
+    BOOST_CHECK_THROW(
+        synthclone::exporter_type(
+            {
+                .editor_ops = std::make_unique<test_editor_ops>(),
+                .metadata = metadata_1
+            }),
+        synthclone::verification_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/modules/synthclone.core/tests/importer.cpp
+++ b/modules/synthclone.core/tests/importer.cpp
@@ -1,0 +1,204 @@
+#include <boost/test/unit_test.hpp>
+
+import std;
+
+import synthclone.core;
+import synthclone.core.tests;
+import synthclone.test;
+import synthclone.util;
+
+class QWindow;
+
+namespace {
+
+    class test_core_ops final: public synthclone::importer_core_ops {
+
+    public:
+
+        std::unique_ptr<synthclone::importer_instance>
+        create()
+        override final
+        {
+            return nullptr;
+        }
+
+        std::generator<synthclone::importer_run_message>
+        run(
+            synthclone::importer_instance& instance,
+            std::stop_token stop_token
+        )
+        override final
+        {
+            co_return;
+        }
+
+    };
+
+    class test_editor_ops final: public synthclone::importer_editor_ops {
+
+    public:
+
+        std::generator<synthclone::importer_edit_message>
+        edit(
+            synthclone::importer_instance& instance,
+            ::QWindow& window,
+            std::stop_token stop_token
+        )
+        override final
+        {
+            co_return;
+        }
+
+    };
+
+    class test_instance final: public synthclone::importer_instance {};
+
+    class test_state_ops final: public synthclone::importer_state_ops {
+
+    public:
+
+        synthclone::state_value
+        dump(const synthclone::importer_instance& instance)
+        override final
+        {
+            return synthclone::state_value();
+        }
+
+        std::unique_ptr<synthclone::importer_instance>
+        load(const synthclone::state_value& value)
+        override final
+        {
+            return nullptr;
+        }
+
+    };
+
+    void
+    verify_type(
+        const synthclone::importer_type& type,
+        const synthclone::importer_core_ops* expected_core_ops_ptr,
+        const synthclone::importer_editor_ops* expected_editor_ops_ptr,
+        const synthclone::importer_state_ops* expected_state_ops_ptr,
+        const synthclone::metadata& expected_metadata
+    )
+    {
+        synthclone::verify_eq(expected_core_ops_ptr, type.core_ops().get());
+        synthclone::verify_eq(
+            expected_editor_ops_ptr, type.editor_ops().get());
+        synthclone::verify_eq(expected_state_ops_ptr, type.state_ops().get());
+        synthclone::verify_eq(expected_metadata, type.metadata());
+    }
+
+}
+
+BOOST_AUTO_TEST_SUITE(importer)
+
+BOOST_AUTO_TEST_CASE(instance)
+{
+    std::unique_ptr<synthclone::importer_instance> instance(
+        std::make_unique<test_instance>());
+    instance.reset();
+}
+
+BOOST_AUTO_TEST_CASE(types)
+{
+    auto core_ops_1 = std::make_unique<test_core_ops>();
+    const auto* core_ops_1_ptr = core_ops_1.get();
+    auto editor_ops_1 = std::make_unique<test_editor_ops>();
+    const auto* editor_ops_1_ptr = editor_ops_1.get();
+    synthclone::metadata metadata_1(
+        {
+            .identifier = "foo",
+            .version = "1.2.3"
+        });
+    synthclone::importer_type type_1(
+        {
+            .core_ops = std::move(core_ops_1),
+            .editor_ops = std::move(editor_ops_1),
+            .metadata = metadata_1
+        });
+    verify_type(type_1, core_ops_1_ptr, editor_ops_1_ptr, nullptr, metadata_1);
+
+    auto core_ops_2 = std::make_unique<test_core_ops>();
+    const auto* core_ops_2_ptr = core_ops_2.get();
+    auto editor_ops_2 = std::make_unique<test_editor_ops>();
+    const auto* editor_ops_2_ptr = editor_ops_2.get();
+    auto state_ops_2 = std::make_unique<test_state_ops>();
+    const auto* state_ops_2_ptr = state_ops_2.get();
+
+    synthclone::metadata metadata_2(
+        {
+            .identifier = "bar",
+            .version = "4.5.6"
+        });
+    synthclone::importer_type type_2(
+        {
+            .core_ops = std::move(core_ops_2),
+            .editor_ops = std::move(editor_ops_2),
+            .state_ops = std::move(state_ops_2),
+            .metadata = metadata_2
+        });
+    verify_type(
+        type_2, core_ops_2_ptr, editor_ops_2_ptr, state_ops_2_ptr, metadata_2);
+
+    synthclone::importer_type type_3 = std::move(type_1);
+    verify_type(type_3, core_ops_1_ptr, editor_ops_1_ptr, nullptr, metadata_1);
+
+    type_1 = std::move(type_2);
+    verify_type(
+        type_1, core_ops_2_ptr, editor_ops_2_ptr, state_ops_2_ptr, metadata_2);
+
+    BOOST_CHECK_THROW(
+        synthclone::importer_type(
+            {
+                .core_ops = std::make_unique<test_core_ops>(),
+                .metadata = metadata_1
+            }),
+        synthclone::verification_error);
+    BOOST_CHECK_THROW(
+        synthclone::importer_type(
+            {
+                .editor_ops = std::make_unique<test_editor_ops>(),
+                .metadata = metadata_1
+            }),
+        synthclone::verification_error);
+}
+
+BOOST_AUTO_TEST_CASE(zone_messages)
+{
+    synthclone::midi_control_array unset_controls;
+
+    synthclone::importer_zone_message message_1(
+        synthclone::zone_port_params(
+            {
+                .channel = 2,
+                .note = 40,
+                .velocity = 70
+            }));
+    synthclone::verify_zone_port_params(
+        message_1.params(), 2, 40, 70, std::nullopt, std::nullopt,
+        unset_controls, std::nullopt);
+
+    synthclone::importer_zone_message message_2(
+        synthclone::zone_port_params(
+            {
+                .channel = 4,
+                .note = 80,
+                .velocity = 35
+            }));
+    synthclone::verify_zone_port_params(
+        message_2.params(), 4, 80, 35, std::nullopt, std::nullopt,
+        unset_controls, std::nullopt);
+
+    synthclone::importer_zone_message message_3(std::move(message_1));
+    synthclone::verify_zone_port_params(
+        message_3.params(), 2, 40, 70, std::nullopt, std::nullopt,
+        unset_controls, std::nullopt);
+
+    message_1 = std::move(message_2);
+    synthclone::verify_zone_port_params(
+        message_1.params(), 4, 80, 35, std::nullopt, std::nullopt,
+        unset_controls, std::nullopt);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/modules/synthclone.core/tests/metadata.cpp
+++ b/modules/synthclone.core/tests/metadata.cpp
@@ -94,49 +94,6 @@ BOOST_AUTO_TEST_CASE(metadata)
     synthclone::verify_eq(metadata_2, metadata_4);
 }
 
-BOOST_AUTO_TEST_CASE(metadata_elements)
-{
-    synthclone::metadata_element element_1("foo");
-    synthclone::verify_eq(element_1, "foo");
-
-    synthclone::metadata_element element_2("bar");
-    synthclone::verify_eq(element_2, "bar");
-
-    synthclone::verify_ne(element_1, element_2);
-
-    synthclone::metadata_element element_3(element_1);
-    synthclone::verify_eq(element_1, element_3);
-
-    synthclone::metadata_element element_4(std::move(element_1));
-    synthclone::verify_eq(element_3, element_4);
-
-    element_1 = element_2;
-    synthclone::verify_eq(element_1, element_2);
-
-    element_4 = std::move(element_1);
-    synthclone::verify_eq(element_2, element_4);
-
-    BOOST_CHECK_THROW(
-        synthclone::metadata_element(""), synthclone::metadata_error);
-    BOOST_CHECK_THROW(
-        synthclone::metadata_element("foo\n"), synthclone::metadata_error);
-    BOOST_CHECK_THROW(
-        synthclone::metadata_element("foo\v"), synthclone::metadata_error);
-    BOOST_CHECK_THROW(
-        synthclone::metadata_element("foo\f"), synthclone::metadata_error);
-    BOOST_CHECK_THROW(
-        synthclone::metadata_element("foo\r"), synthclone::metadata_error);
-    BOOST_CHECK_THROW(
-        synthclone::metadata_element("foo\U00000085"),
-        synthclone::metadata_error);
-    BOOST_CHECK_THROW(
-        synthclone::metadata_element("foo\U00002028"),
-        synthclone::metadata_error);
-    BOOST_CHECK_THROW(
-        synthclone::metadata_element("foo\U00002029"),
-        synthclone::metadata_error);
-}
-
 BOOST_AUTO_TEST_CASE(metadata_urls)
 {
     synthclone::metadata_url url_1("http://somewhere.dev/yup");

--- a/modules/synthclone.core/tests/midi_core.cpp
+++ b/modules/synthclone.core/tests/midi_core.cpp
@@ -1,7 +1,6 @@
-#include <cstdint>
-#include <optional>
-
 #include <boost/test/unit_test.hpp>
+
+import std;
 
 import synthclone.core;
 import synthclone.test;
@@ -32,6 +31,11 @@ BOOST_AUTO_TEST_CASE(aftertouch_constructor)
 BOOST_AUTO_TEST_CASE(channel_constructor)
 {
     verify_byte_constructor<synthclone::midi_channel, 15>();
+}
+
+BOOST_AUTO_TEST_CASE(channel_pressure_constructor)
+{
+    verify_byte_constructor<synthclone::midi_channel_pressure>();
 }
 
 BOOST_AUTO_TEST_CASE(control_index_constructor)

--- a/modules/synthclone.core/tests/module.cppm
+++ b/modules/synthclone.core/tests/module.cppm
@@ -1,7 +1,9 @@
 export module synthclone.core.tests;
 
+export import :audio;
 export import :audio_decoder;
 export import :audio_encoder;
 export import :audio_resampler;
 export import :frequency;
 export import :reference;
+export import :zone;

--- a/modules/synthclone.core/tests/sampler.cpp
+++ b/modules/synthclone.core/tests/sampler.cpp
@@ -1,0 +1,169 @@
+#include <boost/test/unit_test.hpp>
+
+import std;
+
+import synthclone.core;
+import synthclone.test;
+import synthclone.util;
+
+class QWindow;
+
+namespace {
+
+    class test_core_ops final: public synthclone::sampler_core_ops {
+
+    public:
+
+        std::unique_ptr<synthclone::sampler_instance>
+        create()
+        override final
+        {
+            return nullptr;
+        }
+
+        std::generator<synthclone::sampler_capture_message>
+        capture(
+            synthclone::sampler_instance& instance,
+            const synthclone::zone_capture_params& capture_params,
+            synthclone::audio_output_stream& output_stream,
+            std::stop_token stop_token
+        )
+        override final
+        {
+            co_return;
+        }
+
+        std::generator<synthclone::sampler_play_message>
+        play(
+            synthclone::sampler_instance& instance,
+            synthclone::audio_input_stream& input_stream,
+            std::stop_token stop_token
+        )
+        override final
+        {
+            co_return;
+        }
+
+    };
+
+    class test_editor_ops final: public synthclone::sampler_editor_ops {
+
+    public:
+
+        std::generator<synthclone::sampler_edit_message>
+        edit(
+            synthclone::sampler_instance& instance,
+            ::QWindow& window,
+            std::stop_token stop_token
+        )
+        override final
+        {
+            co_return;
+        }
+
+    };
+
+    class test_instance final: public synthclone::sampler_instance {};
+
+    class test_state_ops final: public synthclone::sampler_state_ops {
+
+    public:
+
+        synthclone::state_value
+        dump(const synthclone::sampler_instance& instance)
+        override final
+        {
+            return synthclone::state_value();
+        }
+
+        std::unique_ptr<synthclone::sampler_instance>
+        load(const synthclone::state_value& value)
+        override final
+        {
+            return nullptr;
+        }
+
+    };
+
+    void
+    verify_type(
+        const synthclone::sampler_type& type,
+        const synthclone::sampler_core_ops* expected_core_ops_ptr,
+        const synthclone::sampler_editor_ops* expected_editor_ops_ptr,
+        const synthclone::sampler_state_ops* expected_state_ops_ptr,
+        const synthclone::metadata& expected_metadata
+    )
+    {
+        synthclone::verify_eq(expected_core_ops_ptr, type.core_ops().get());
+        synthclone::verify_eq(
+            expected_editor_ops_ptr, type.editor_ops().get());
+        synthclone::verify_eq(expected_state_ops_ptr, type.state_ops().get());
+        synthclone::verify_eq(expected_metadata, type.metadata());
+    }
+
+}
+
+BOOST_AUTO_TEST_SUITE(sampler)
+
+BOOST_AUTO_TEST_CASE(instance)
+{
+    std::unique_ptr<synthclone::sampler_instance> instance(
+        std::make_unique<test_instance>());
+    instance.reset();
+}
+
+BOOST_AUTO_TEST_CASE(types)
+{
+    auto core_ops_1 = std::make_unique<test_core_ops>();
+    const auto* core_ops_1_ptr = core_ops_1.get();
+    synthclone::metadata metadata_1(
+        {
+            .identifier = "foo",
+            .version = "1.2.3"
+        });
+    synthclone::sampler_type type_1(
+        {
+            .core_ops = std::move(core_ops_1),
+            .metadata = metadata_1
+        });
+    verify_type(type_1, core_ops_1_ptr, nullptr, nullptr, metadata_1);
+
+    auto core_ops_2 = std::make_unique<test_core_ops>();
+    const auto* core_ops_2_ptr = core_ops_2.get();
+    auto editor_ops_2 = std::make_unique<test_editor_ops>();
+    const auto* editor_ops_2_ptr = editor_ops_2.get();
+    auto state_ops_2 = std::make_unique<test_state_ops>();
+    const auto* state_ops_2_ptr = state_ops_2.get();
+
+    synthclone::metadata metadata_2(
+        {
+            .identifier = "bar",
+            .version = "4.5.6"
+        });
+    synthclone::sampler_type type_2(
+        {
+            .core_ops = std::move(core_ops_2),
+            .editor_ops = std::move(editor_ops_2),
+            .state_ops = std::move(state_ops_2),
+            .metadata = metadata_2
+        });
+    verify_type(
+        type_2, core_ops_2_ptr, editor_ops_2_ptr, state_ops_2_ptr, metadata_2);
+
+    synthclone::sampler_type type_3 = std::move(type_1);
+    verify_type(type_3, core_ops_1_ptr, nullptr, nullptr, metadata_1);
+
+    type_1 = std::move(type_2);
+    verify_type(
+        type_1, core_ops_2_ptr, editor_ops_2_ptr, state_ops_2_ptr, metadata_2);
+
+    BOOST_CHECK_THROW(
+        synthclone::sampler_type(
+            {
+                .core_ops = nullptr,
+                .metadata = metadata_1
+            }),
+        synthclone::verification_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/modules/synthclone.core/tests/zone.cpp
+++ b/modules/synthclone.core/tests/zone.cpp
@@ -1,0 +1,163 @@
+#include <boost/test/unit_test.hpp>
+
+import std;
+
+import synthclone.core;
+import synthclone.core.tests;
+import synthclone.test;
+
+namespace {
+
+    template<std::uint8_t... Values>
+    synthclone::midi_control_array
+    make_sample_control_array(
+        std::integer_sequence<std::uint_least8_t, Values...>
+    )
+    {
+        return synthclone::midi_control_array {
+            Values...
+        };
+    }
+
+    void
+    verify_zone_capture_params(
+        const synthclone::zone_capture_params& params,
+        synthclone::midi_channel expected_channel,
+        synthclone::midi_note expected_note,
+        synthclone::midi_velocity expected_velocity,
+        std::optional<synthclone::midi_aftertouch> expected_aftertouch,
+        std::optional<synthclone::midi_channel_pressure> expected_pressure,
+        const synthclone::midi_control_array& expected_controls,
+        synthclone::audio_duration expected_sample_duration,
+        synthclone::audio_duration expected_release_duration
+    )
+    {
+        BOOST_TEST_INFO_SCOPE(
+            synthclone::make_test_info(
+                "verify_zone_capture_params", params, expected_channel,
+                expected_note, expected_velocity, expected_aftertouch,
+                expected_pressure, expected_controls, expected_sample_duration,
+                expected_release_duration));
+
+        synthclone::verify_eq(expected_channel, params.channel());
+        synthclone::verify_eq(expected_note, params.note());
+        synthclone::verify_eq(expected_velocity, params.velocity());
+        synthclone::verify_eq(expected_aftertouch, params.aftertouch());
+        synthclone::verify_eq(expected_pressure, params.channel_pressure());
+        synthclone::verify_eq(expected_controls, params.controls());
+        synthclone::verify_eq(
+            expected_sample_duration, params.sample_duration());
+        synthclone::verify_eq(
+            expected_release_duration, params.release_duration());
+    }
+
+    void
+    verify_zone_capture_params(
+        const synthclone::zone_capture_params& expected_params,
+        const synthclone::zone_capture_params& actual_params
+    )
+    {
+        BOOST_TEST_INFO_SCOPE(
+            synthclone::make_test_info(
+                "verify_zone_capture_params", expected_params, actual_params));
+
+        verify_zone_capture_params(
+            actual_params, expected_params.channel(), expected_params.note(),
+            expected_params.velocity(), expected_params.aftertouch(),
+            expected_params.channel_pressure(), expected_params.controls(),
+            expected_params.sample_duration(),
+            expected_params.release_duration());
+    }
+
+}
+
+BOOST_AUTO_TEST_SUITE(zone)
+
+BOOST_AUTO_TEST_CASE(zone_capture_params)
+{
+    synthclone::midi_control_array unset_controls;
+    synthclone::zone_capture_params params_1(
+        {
+            .channel = 1,
+            .note = 40,
+            .velocity = 100,
+            .sample_duration = 1,
+            .release_duration = 2
+        });
+
+    verify_zone_capture_params(
+        params_1, 1, 40, 100, std::nullopt, std::nullopt, unset_controls, 1,
+        2);
+
+    synthclone::midi_control_array set_controls = make_sample_control_array(
+        std::make_integer_sequence<std::uint_least8_t, 128>{});
+    synthclone::zone_capture_params params_2(
+        {
+            .channel = 10,
+            .note = 80,
+            .velocity = 127,
+            .aftertouch = 72,
+            .channel_pressure = 84,
+            .controls = set_controls,
+            .sample_duration = 4,
+            .release_duration = 8
+        });
+    verify_zone_capture_params(
+        params_2, 10, 80, 127, 72, 84, set_controls, 4, 8);
+
+    synthclone::zone_capture_params params_3(params_1);
+
+    verify_zone_capture_params(params_1, params_3);
+
+    params_1 = params_2;
+
+    verify_zone_capture_params(params_2, params_1);
+}
+
+BOOST_AUTO_TEST_CASE(zone_port_params)
+{
+    synthclone::midi_control_array unset_controls;
+    synthclone::zone_port_params params_1(
+        {
+            .channel = 1,
+            .note = 40,
+            .velocity = 100
+        });
+
+    synthclone::verify_zone_port_params(
+        params_1, 1, 40, 100, std::nullopt, std::nullopt, unset_controls,
+        std::nullopt);
+
+    synthclone::midi_control_array set_controls = make_sample_control_array(
+        std::make_integer_sequence<std::uint_least8_t, 128>{});
+    synthclone::zone_port_params params_2(
+        {
+            .channel = 10,
+            .note = 80,
+            .velocity = 127,
+            .aftertouch = 72,
+            .channel_pressure = 84,
+            .controls = set_controls,
+            .input_stream =
+                synthclone::make_reference_audio_input_stream<8000, 1>()
+        });
+    synthclone::verify_zone_port_params(
+        params_2, 10, 80, 127, 72, 84, set_controls,
+        synthclone::make_reference_audio_input_stream<8000, 1>());
+
+    synthclone::zone_port_params params_3(std::move(params_1));
+
+    synthclone::verify_zone_port_params(
+        params_1, 1, 40, 100, std::nullopt, std::nullopt, unset_controls,
+        std::nullopt);
+
+    // The stream is mutated when we verify zone index equality.
+    (*(params_2.input_stream())).seek(0, synthclone::audio_seek_origin::start);
+    params_1 = std::move(params_2);
+
+    synthclone::verify_zone_port_params(
+        params_1, 10, 80, 127, 72, 84, set_controls,
+        synthclone::make_reference_audio_input_stream<8000, 1>());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/modules/synthclone.core/tests/zone.cppm
+++ b/modules/synthclone.core/tests/zone.cppm
@@ -1,0 +1,56 @@
+module;
+
+#include <boost/test/unit_test.hpp>
+
+export module synthclone.core.tests:zone;
+
+import std;
+
+import synthclone.core;
+import synthclone.test;
+
+import :audio;
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::verify_zone_port_params()
+///////////////////////////////////////////////////////////////////////////////
+
+namespace synthclone {
+
+    export
+    void
+    verify_zone_port_params(
+        zone_port_params& params,
+        midi_channel expected_channel,
+        midi_note expected_note,
+        midi_velocity expected_velocity,
+        std::optional<midi_aftertouch> expected_aftertouch,
+        std::optional<midi_channel_pressure> expected_pressure,
+        const midi_control_array& expected_controls,
+        std::optional<audio_input_stream> expected_input_stream
+    )
+    {
+        BOOST_TEST_INFO_SCOPE(
+            make_test_info(
+                "synthclone::verify_zone_port_params", params,
+                expected_channel, expected_note, expected_velocity,
+                expected_aftertouch, expected_pressure, expected_controls,
+                expected_input_stream));
+
+        verify_eq(expected_channel, params.channel());
+        verify_eq(expected_note, params.note());
+        verify_eq(expected_velocity, params.velocity());
+        verify_eq(expected_aftertouch, params.aftertouch());
+        verify_eq(expected_pressure, params.channel_pressure());
+        verify_eq(expected_controls, params.controls());
+
+        auto& actual_input_stream = params.input_stream();
+        if (! expected_input_stream) {
+            BOOST_CHECK(! actual_input_stream);
+        } else {
+            verify_audio_input_stream(
+                *expected_input_stream, *actual_input_stream);
+        }
+    }
+
+}

--- a/modules/synthclone.util/src/unicode.cppm
+++ b/modules/synthclone.util/src/unicode.cppm
@@ -21,10 +21,12 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
     export using synthclone::unicode_error;
     export using synthclone::utf8_decode_iterator;
     export using synthclone::utf8_decode_view;
+    export using synthclone::utf8_line;
     export using synthclone::utf8_string;
 
     export using synthclone::decode_utf8;
     export using synthclone::get_category;
     export using synthclone::get_identifier;
+    export using synthclone::is_line_terminator;
 
 }

--- a/modules/synthclone.util/src/unicode_core.cppm
+++ b/modules/synthclone.util/src/unicode_core.cppm
@@ -76,6 +76,14 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
 
     using utf8_byte_iterator = const std::byte*;
 
+    constexpr char32_t unicode_carriage_return = '\r';
+    constexpr char32_t unicode_form_feed = '\f';
+    constexpr char32_t unicode_line_feed = '\n';
+    constexpr char32_t unicode_line_separator = U'\U00002028';
+    constexpr char32_t unicode_next_line = U'\U00000085';
+    constexpr char32_t unicode_paragraph_separator = U'\U00002029';
+    constexpr char32_t unicode_vertical_tab = '\v';
+
     char32_t
     verify_unicode_codepoint(const char32_t n)
     {
@@ -124,7 +132,7 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
     /**
      * Gets the codepoint category.
      *
-     * @param c
+     * @param codepoint
      *   The codepoint.
      *
      * @return
@@ -134,11 +142,45 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
     export
     inline
     unicode_category
-    get_category(unicode_codepoint c)
+    get_category(const unicode_codepoint codepoint)
     noexcept
     {
         return static_cast<unicode_category>(
-            ::utf8proc_category(static_cast<::utf8proc_int32_t>(c.value())));
+            ::utf8proc_category(
+                static_cast<::utf8proc_int32_t>(codepoint.value())));
+    }
+
+    /**
+     * Gets a boolean indicating whether or not the given codepoint is a line
+     * terminator.
+     *
+     * @param c
+     *   The codepoint.
+     *
+     * @return
+     *   The boolean indicator.
+     */
+
+    export
+    constexpr
+    bool
+    is_line_terminator(const unicode_codepoint c)
+    noexcept
+    {
+        switch (c.value()) {
+        case unicode_carriage_return:
+        case unicode_form_feed:
+        case unicode_line_feed:
+        case unicode_line_separator:
+        case unicode_next_line:
+        case unicode_paragraph_separator:
+        case unicode_vertical_tab:
+            return true;
+
+        default:
+            ;
+        }
+        return false;
     }
 
 }
@@ -534,6 +576,68 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
         utf8_string(Args&&... args):
             string_proxy<utf8_string>(
                 verify_utf8_string(std::string(std::forward<Args>(args)...)))
+        {
+            // empty
+        }
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::utf8_line
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    std::string&&
+    verify_utf8_line(std::string&& s)
+    {
+        std::ranges::for_each(
+            decode_utf8(std::as_bytes(std::span(s))),
+            [](const unicode_codepoint c) {
+                if (is_line_terminator(c)) [[unlikely]] {
+                    throw unicode_error(
+                        std::format(
+                            "codepoint {0} is a line terminator - line "
+                            "terminators must not be present in a `utf8_line`",
+                            static_cast<std::uint_least32_t>(c)));
+                }
+            });
+        return std::move(s);
+    }
+
+    /**
+     * A UTF-8 string type that can hold any UTF-8 encoded data except line
+     * terminators.
+     */
+
+    export
+    class utf8_line final: public string_proxy<utf8_line> {
+
+    public:
+
+        /**
+         * Constructs a `utf8_line` instance.
+         *
+         * @param args
+         *   The arguments to pass to the `std::string` constructor.
+         */
+
+        template<class... Args>
+        requires (std::constructible_from<std::string, Args...>)
+        explicit (
+            (sizeof...(Args) != 1) ||
+            (
+                ! implicitly_convertible_to<
+                    boost::mp11::mp_front<boost::mp11::mp_list<Args...>>,
+                    std::string
+                >
+            )
+        )
+        utf8_line(Args&&... args):
+            string_proxy<utf8_line>(
+                verify_utf8_line(std::string(std::forward<Args>(args)...)))
         {
             // empty
         }

--- a/modules/synthclone.util/tests/unicode_core.cpp
+++ b/modules/synthclone.util/tests/unicode_core.cpp
@@ -46,6 +46,40 @@ namespace {
     }
 
     void
+    verify_invalid_utf8_line(const std::string& s)
+    {
+        BOOST_TEST_INFO_SCOPE(
+            synthclone::make_test_info("verify_invalid_utf8_line", s));
+
+        BOOST_CHECK_THROW(synthclone::utf8_line{s}, synthclone::unicode_error);
+    }
+
+    void
+    verify_line_terminator(char32_t n)
+    {
+        BOOST_TEST_INFO_SCOPE(
+            synthclone::make_test_info(
+                "verify_line_terminator",
+                static_cast<std::uint_least32_t>(n)));
+
+        BOOST_CHECK(
+            synthclone::is_line_terminator(synthclone::unicode_codepoint(n)));
+    }
+
+    void
+    verify_non_line_terminator(char32_t n)
+    {
+        BOOST_TEST_INFO_SCOPE(
+            synthclone::make_test_info(
+                "verify_non_line_terminator",
+                static_cast<std::uint_least32_t>(n)));
+
+        BOOST_CHECK(
+            ! synthclone::is_line_terminator(
+                synthclone::unicode_codepoint(n)));
+    }
+
+    void
     verify_valid_codepoint(char32_t n)
     {
         BOOST_TEST_INFO_SCOPE(
@@ -95,6 +129,21 @@ BOOST_AUTO_TEST_CASE(codepoint_categories)
     }
 }
 
+BOOST_AUTO_TEST_CASE(codepoint_line_terminators)
+{
+    verify_line_terminator('\n');
+    verify_line_terminator('\v');
+    verify_line_terminator('\r');
+    verify_line_terminator('\f');
+    verify_line_terminator(U'\U00000085');
+    verify_line_terminator(U'\U00002028');
+    verify_line_terminator(U'\U00002029');
+
+    for (char32_t i = 0x20; i < 0x80; ++i) {
+        verify_non_line_terminator(i);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(invalid_utf8_decode_iterator)
 {
     synthclone::utf8_decode_iterator invalid_iter;
@@ -113,6 +162,17 @@ BOOST_AUTO_TEST_CASE(invalid_unicode_codepoints)
     for (char32_t c = 0x110000; c < 0x110010; ++c) {
         verify_invalid_codepoint(c);
     }
+}
+
+BOOST_AUTO_TEST_CASE(invalid_utf8_lines)
+{
+    verify_invalid_utf8_line("foo\n");
+    verify_invalid_utf8_line("foo\v");
+    verify_invalid_utf8_line("foo\f");
+    verify_invalid_utf8_line("foo\r");
+    verify_invalid_utf8_line("foo\U00000085");
+    verify_invalid_utf8_line("foo\U00002028");
+    verify_invalid_utf8_line("foo\U00002029");
 }
 
 BOOST_AUTO_TEST_CASE(invalid_utf8_strings)
@@ -242,6 +302,29 @@ BOOST_AUTO_TEST_CASE(valid_unicode_codepoints)
     }
 }
 
+BOOST_AUTO_TEST_CASE(valid_utf8_lines)
+{
+    synthclone::utf8_line line_1("foo");
+    synthclone::verify_eq(line_1, "foo");
+
+    synthclone::utf8_line line_2("bar");
+    synthclone::verify_eq(line_2, "bar");
+
+    synthclone::verify_ne(line_1, line_2);
+
+    synthclone::utf8_line line_3(line_1);
+    synthclone::verify_eq(line_1, line_3);
+
+    synthclone::utf8_line line_4(std::move(line_1));
+    synthclone::verify_eq(line_3, line_4);
+
+    line_1 = line_2;
+    synthclone::verify_eq(line_1, line_2);
+
+    line_4 = std::move(line_1);
+    synthclone::verify_eq(line_2, line_4);
+}
+
 BOOST_AUTO_TEST_CASE(valid_utf8_strings)
 {
     for (auto i = 0; i < 0x10; ++i) {
@@ -260,7 +343,6 @@ BOOST_AUTO_TEST_CASE(valid_utf8_strings)
         verify_valid_utf8(std::string {c1, c2, '\xbf', '\xbe'}, i);
         verify_valid_utf8(std::string {c1, c2, '\xbf', '\xbf'}, i + 1);
     }
-
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add plugin components and related functionality:
* Add base component type templates used by more specific component interfaces.
* Add common messages used by component types.
* Add types for effect components, which are used to transform audio data.
* Add types for exporter components, which are used to export zone data.
* Add types for importer components, which are used to import zone data.
* Add types for sampler components, which are used to capture and playback audio.
* Add zone params types that contain data used by exporters, importers, and samplers.
* Put UTF-8 line functionality in `synthclone.util` so it's more accessible.
* Add `synthclone::is_line_terminator()` to check if a codepoint is a line terminator.
* Move common audio verification routines to `synthclone.core.tests` module.
* Add `synthclone::midi_control_array` to hold optional values for 128 controls.
* Add `synthclone::midi_channel_pressure` which I somehow overlooked.
* "Fix" coverage results by ignoring certain errors.
* Add tests for new functionality.