### PR TITLE
Add plugin and session communication interfaces.

### DIFF
--- a/common/cmake/config.cmake
+++ b/common/cmake/config.cmake
@@ -70,7 +70,7 @@ function(synthclone_initialize_config)
             --function-coverage
             --demangle-cpp
             --erase-functions __cxx_global_var_init
-            --ignore-errors inconsistent
+            --ignore-errors format,inconsistent
             --directory ${CMAKE_SOURCE_DIR}
             --base-directory ${CMAKE_SOURCE_DIR}
             --gcov-tool "${LLVM_COV}" --gcov-tool gcov

--- a/modules/synthclone.core/src/module.cppm
+++ b/modules/synthclone.core/src/module.cppm
@@ -13,6 +13,8 @@ export import :exporter;
 export import :importer;
 export import :metadata;
 export import :midi;
+export import :plugin;
 export import :sampler;
+export import :session;
 export import :state;
 export import :zone;

--- a/modules/synthclone.core/src/plugin.cppm
+++ b/modules/synthclone.core/src/plugin.cppm
@@ -1,0 +1,180 @@
+/**
+ * @file
+ *
+ * Contains interfaces for plugins.
+ */
+
+module;
+
+#include <synthclone/config.h>
+
+export module synthclone.core:plugin;
+
+import std;
+
+import synthclone.util;
+
+import :effect;
+import :exporter;
+import :importer;
+import :metadata;
+import :sampler;
+import :session;
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::plugin_instance
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Represents a plugin instance loaded into a specific session.
+     */
+
+    export
+    class plugin_instance: private nonmovable {
+
+    public:
+
+        /**
+         * Destructor.
+         */
+
+        virtual
+        ~plugin_instance() = default;
+
+        /**
+         * Gets an `effect_type` instance for each effect type provided by this
+         * plugin.
+         *
+         * @return
+         *   A generator yielding `effect_type` instances.
+         */
+
+        virtual
+        std::generator<effect_type>
+        effect_types()
+        {
+            co_return;
+        }
+
+        /**
+         * Gets an `exporter_type` instance for each exporter type provided by
+         * this plugin.
+         *
+         * @return
+         *   A generator yielding `exporter_type` instances.
+         */
+
+        virtual
+        std::generator<exporter_type>
+        exporter_types()
+        {
+            co_return;
+        }
+
+        /**
+         * Gets an `importer_type` instance for each importer type provided by
+         * this plugin.
+         *
+         * @return
+         *   A generator yielding `importer_type` instances.
+         */
+
+        virtual
+        std::generator<importer_type>
+        importer_types()
+        {
+            co_return;
+        }
+
+        /**
+         * Gets a `sampler_type` instance for each sampler type provided by
+         * this plugin.
+         *
+         * @return
+         *   A generator yielding `sampler_type` instances.
+         */
+
+        virtual
+        std::generator<sampler_type>
+        sampler_types()
+        {
+            co_return;
+        }
+
+    protected:
+
+        /**
+         * Default constructor.
+         */
+
+        explicit
+        plugin_instance() = default;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::plugin
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Represents a `synthclone` plugin.
+     *
+     * XXX: Add details on how `synthclone` instantiates `plugin` subclasses.
+     */
+
+    export
+    class plugin: private nonmovable {
+
+    public:
+
+        /**
+         * Destructor.
+         */
+
+        virtual
+        ~plugin() = default;
+
+        /**
+         * Creates a plugin for the session described by the given host.
+         *
+         * @param host
+         *   Allows the plugin to interact with `synthclone` and get session
+         *   properties.
+         *
+         * @return
+         *   The plugin instance.
+         */
+
+        virtual
+        std::unique_ptr<plugin_instance>
+        instantiate(session_host& host) = 0;
+
+        /**
+         * Gets the metadata for the plugin.
+         *
+         * @return
+         *   The metadata.
+         */
+
+        virtual
+        const metadata&
+        metadata() = 0;
+
+    protected:
+
+        /**
+         * Default constructor.
+         */
+
+        explicit
+        plugin() = default;
+
+    };
+
+}

--- a/modules/synthclone.core/src/session.cppm
+++ b/modules/synthclone.core/src/session.cppm
@@ -1,0 +1,278 @@
+/**
+ * @file
+ *
+ * Specifies aspects of `synthclone` sessions that are available to plugins.
+ *
+ * XXX: The logging functionality here may very well change.  It's a
+ * placeholder for something potentially better.
+ */
+
+module;
+
+#include <synthclone/config.h>
+
+export module synthclone.core:session;
+
+import std;
+
+import synthclone.util;
+
+import :audio;
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::session_log_level
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Valid log levels.
+     */
+
+    export
+    enum class session_log_level: std::uint8_t {
+
+        /**
+         * Log level for a log entry that may be helpful for debugging.
+         */
+
+        debug = 0,
+
+        /**
+         * Log level for a log entry that holds a point of interest.
+         */
+
+        info = 1,
+
+        /**
+         * Log level for a log entry that indicates an issue, but one that is
+         * non-critical/recoverable.
+         */
+
+        warning = 2,
+
+        /**
+         * Log level for a log entry that indicates an error.
+         */
+
+        error = 3
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::session_log
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Application-specific log destination.
+     */
+
+    export
+    class session_log: private nonmovable {
+
+    public:
+
+        /**
+         * Emits a log entry to the session log.
+         *
+         * @param level
+         *   The log level.
+         * @param message
+         *   The log message.
+         * @param location
+         *   The source location where the log message was crafted.
+         */
+
+        virtual
+        void
+        emit(
+            session_log_level level,
+            const std::string& message,
+            const std::source_location& location
+        ) = 0;
+
+    protected:
+
+        /**
+         * Default constructor.
+         */
+
+        explicit
+        session_log() = default;
+
+        /**
+         * Destructor.
+         */
+
+        ~session_log() = default;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::session_logger
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    session_log_level
+    verify_session_log_level(session_log_level level)
+    {
+        auto level_n = std::to_underlying(level);
+        verify(
+            std::to_underlying(level) <=
+            std::to_underlying(session_log_level::error),
+            "{0}: invalid log level value", level_n);
+        return level;
+    }
+
+    /**
+     * Allows plugins to write log entries to an application logger.
+     */
+
+    export
+    class session_logger final: private nonmovable {
+
+    public:
+
+        /**
+         * Constructs a `session_logger` instance.
+         *
+         * @param level_threshold
+         *   The minimum log level for a given log entry to be emitted to the
+         *   given session log.
+         */
+
+        explicit
+        session_logger(session_log& log, session_log_level level_threshold):
+            log_(log),
+            level_threshold_(verify_session_log_level(level_threshold))
+        {
+            // empty
+        }
+
+        /**
+         * Writes a log entry to the session log if the given log level is
+         * greater than or equal to the log level threshold.
+         *
+         * @param level
+         *   The log level.
+         * @param s
+         *   A string that will be passed as the `std::format_string` to
+         *   `std::format` to get the final log message.
+         * @param args
+         *   The arguments to use to populate the format string.
+         */
+
+        template<class... Args>
+        void
+        log(
+            session_log_level level,
+            diagnostic_format_string<std::type_identity_t<Args>...> s,
+            Args&&... args
+        )
+        {
+            if (level >= level_threshold_) {
+                log_.emit(
+                    level,
+                    std::format(s.string(), std::forward<Args>(args)...),
+                    s.location());
+            }
+        }
+
+    private:
+
+        session_log& log_;
+        session_log_level level_threshold_;
+
+    };
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::session_host
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
+    /**
+     * Contains information about the session and mechanisms for limited
+     * application functionality exposed to a plugin.
+     */
+
+    export
+    class session_host final {
+
+    public:
+
+        /**
+         * Constructs a `session_host` instance.
+         *
+         * @param logger
+         *   A logger that a plugin can use to write log entries to the session
+         *   log.
+         * @param sample_rate
+         *   The session sample rate.
+         * @param channel_count
+         *   The session channel count.
+         */
+
+        explicit
+        session_host(
+            session_logger& logger,
+            audio_sample_rate sample_rate,
+            audio_channel_count channel_count
+        )
+        noexcept:
+            // XXX: Choose endianness based on native endianness.
+            audio_traits_(
+                audio_format::raw, audio_codec::pcm_f32,
+                audio_endianness::little, sample_rate, channel_count),
+            logger_(logger)
+        {
+            // empty
+        }
+
+        /**
+         * Gets the audio traits used for samples stored in this session.
+         *
+         * @return
+         *   The audio traits.
+         */
+
+        constexpr
+        const audio_traits&
+        audio_traits()
+        const noexcept
+        {
+            return audio_traits_;
+        }
+
+        /**
+         * Gets the session logger.
+         *
+         * @return
+         *   The logger.
+         */
+
+        constexpr
+        session_logger&
+        logger()
+        noexcept
+        {
+            return logger_;
+        }
+
+    private:
+
+        class audio_traits audio_traits_;
+        session_logger& logger_;
+
+    };
+
+}

--- a/modules/synthclone.core/tests/plugin.cpp
+++ b/modules/synthclone.core/tests/plugin.cpp
@@ -1,0 +1,74 @@
+#include <boost/test/unit_test.hpp>
+
+import std;
+
+import synthclone.core;
+import synthclone.test;
+
+namespace {
+
+    class test_instance final: public synthclone::plugin_instance {};
+
+    class test_plugin final: public synthclone::plugin {
+
+    public:
+
+        test_plugin():
+            metadata_(
+                {
+                    .identifier = "identifier",
+                    .version = "version"
+                })
+        {
+            // empty
+        }
+
+        std::unique_ptr<synthclone::plugin_instance>
+        instantiate(synthclone::session_host& host)
+        override final
+        {
+            return nullptr;
+        }
+
+        const synthclone::metadata&
+        metadata()
+        override final
+        {
+            return metadata_;
+        }
+
+    private:
+
+        synthclone::metadata metadata_;
+
+    };
+
+    template<class T>
+    void
+    verify_empty_gen(std::generator<T> gen)
+    {
+        synthclone::verify_eq(gen.begin(), gen.end());
+    }
+
+}
+
+BOOST_AUTO_TEST_SUITE(session)
+
+BOOST_AUTO_TEST_CASE(instance)
+{
+    std::unique_ptr<synthclone::plugin_instance> instance(
+        std::make_unique<test_instance>());
+
+    verify_empty_gen(instance->effect_types());
+    verify_empty_gen(instance->exporter_types());
+    verify_empty_gen(instance->importer_types());
+    verify_empty_gen(instance->sampler_types());
+}
+
+BOOST_AUTO_TEST_CASE(plugin)
+{
+    std::unique_ptr<synthclone::plugin> plugin(
+        std::make_unique<test_plugin>());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/modules/synthclone.core/tests/session.cpp
+++ b/modules/synthclone.core/tests/session.cpp
@@ -1,0 +1,140 @@
+#include <boost/test/unit_test.hpp>
+
+import std;
+
+import synthclone.core;
+import synthclone.core.tests;
+import synthclone.test;
+import synthclone.util;
+
+namespace {
+
+    class host_log final: public synthclone::session_log {
+
+    public:
+
+        explicit
+        host_log() = default;
+
+        void
+        emit(
+            synthclone::session_log_level log_level,
+            const std::string& s,
+            const std::source_location& location
+        )
+        override final
+        {
+            // empty
+        }
+
+    };
+
+    class test_log final: public synthclone::session_log {
+
+    public:
+
+        explicit
+        test_log(
+            synthclone::session_log_level expected_level,
+            std::string expected_string,
+            std::source_location expected_location,
+            std::uint_least32_t expected_line_offset,
+            bool& message_read
+        ):
+            synthclone::session_log(),
+            expected_string_(std::move(expected_string)),
+            expected_location_(std::move(expected_location)),
+            expected_line_offset_(expected_line_offset),
+            expected_level_(expected_level),
+            message_read_(message_read)
+        {
+            // empty
+        }
+
+        void
+        emit(
+            synthclone::session_log_level log_level,
+            const std::string& s,
+            const std::source_location& location
+        )
+        override final
+        {
+            BOOST_TEST_INFO_SCOPE(
+                synthclone::make_test_info("test_log::emit", s, location));
+
+            BOOST_CHECK(! message_read_);
+
+            message_read_ = true;
+
+            synthclone::verify_eq(expected_level_, log_level);
+            synthclone::verify_eq(expected_string_, s);
+
+            synthclone::verify_eq(
+                expected_location_.line(),
+                location.line() - expected_line_offset_);
+            synthclone::verify_eq(
+                expected_location_.function_name(), location.function_name());
+            synthclone::verify_eq(
+                expected_location_.file_name(), location.file_name());
+        }
+
+        std::string expected_string_;
+        std::source_location expected_location_;
+        std::uint_least32_t expected_line_offset_;
+        synthclone::session_log_level expected_level_;
+        bool& message_read_;
+
+    };
+
+}
+
+BOOST_AUTO_TEST_SUITE(session)
+
+BOOST_AUTO_TEST_CASE(host)
+{
+    host_log log;
+    synthclone::session_logger logger(
+        log, synthclone::session_log_level::debug);
+    synthclone::session_host host(logger, 48000, 2);
+
+    synthclone::verify_eq(
+        std::addressof(logger), std::addressof(host.logger()));
+    synthclone::verify_audio_traits(
+        synthclone::audio_traits(
+            synthclone::audio_format::raw, synthclone::audio_codec::pcm_f32,
+            synthclone::audio_endianness::little, 48000, 2),
+        host.audio_traits());
+}
+
+BOOST_AUTO_TEST_CASE(logger)
+{
+    // The placement of this code *actually* matters because we're measuring
+    // `std::source_location` offsets.
+
+    bool message_read = false;
+    const auto location_1 = std::source_location::current();
+    test_log log_1(
+        synthclone::session_log_level::debug, "foo bar baz", location_1, 7,
+        message_read);
+    synthclone::session_logger logger_1(
+        log_1, synthclone::session_log_level::debug);
+    BOOST_CHECK(! message_read);
+    logger_1.log(synthclone::session_log_level::debug, "foo {0} baz", "bar");
+    BOOST_CHECK(message_read);
+
+    message_read = false;
+    const auto location_2 = std::source_location::current();
+    test_log log_2(
+        synthclone::session_log_level::error, "1 2 3 4", location_2, 10,
+        message_read);
+    synthclone::session_logger logger_2(
+        log_2, synthclone::session_log_level::error);
+    logger_2.log(synthclone::session_log_level::debug, "foo {0} baz", "bar");
+    logger_2.log(synthclone::session_log_level::info, "foo {0} baz", "bar");
+    logger_2.log(synthclone::session_log_level::warning, "foo {0} baz", "bar");
+    BOOST_CHECK(! message_read);
+    logger_2.log(synthclone::session_log_level::error, "1 {0} 3 {1}", 2, 4);
+    BOOST_CHECK(message_read);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/modules/synthclone.util/src/debug.cppm
+++ b/modules/synthclone.util/src/debug.cppm
@@ -57,20 +57,24 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// synthclone::assume()
+// synthclone::diagnostic_format_string
 ///////////////////////////////////////////////////////////////////////////////
 
 namespace SYNTHCLONE_LIB_NAMESPACE {
 
+    export
     template<class... Args>
-    class diagnostic_info final {
+    class diagnostic_format_string final {
 
     public:
 
         template<class T>
-        requires (string_view_convertible<const T&>)
+        requires (
+            std::constructible_from<std::format_string<Args...>, const T&>
+        )
+        //requires (string_view_convertible<const T&>)
         consteval
-        diagnostic_info(
+        diagnostic_format_string(
             const T& s,
             std::source_location location = std::source_location::current()
         ) noexcept:
@@ -101,11 +105,19 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
 
     };
 
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// synthclone::assume()
+///////////////////////////////////////////////////////////////////////////////
+
+namespace SYNTHCLONE_LIB_NAMESPACE {
+
     template<class... Args>
     [[noreturn]]
     void
     process_assumption_error(
-        const diagnostic_info<Args...>& info,
+        const diagnostic_format_string<Args...>& info,
         Args&&... args
     )
     {
@@ -157,7 +169,7 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
     void
     assume(
         const bool condition,
-        diagnostic_info<std::type_identity_t<Args>...> info,
+        diagnostic_format_string<std::type_identity_t<Args>...> info,
         Args&&... args
     )
     {
@@ -214,7 +226,7 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
     constexpr
     void
     assume_unreachable(
-        diagnostic_info<std::type_identity_t<Args>...> info,
+        diagnostic_format_string<std::type_identity_t<Args>...> info,
         Args&&... args
     )
     {
@@ -252,7 +264,10 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
     export
     template<class... Args>
     void
-    trace(diagnostic_info<std::type_identity_t<Args>...> info, Args&&... args)
+    trace(
+        diagnostic_format_string<std::type_identity_t<Args>...> info,
+        Args&&... args
+    )
     {
 
 #ifndef NDEBUG
@@ -278,7 +293,7 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
     [[noreturn]]
     void
     process_verification_error(
-        const diagnostic_info<Args...>& info,
+        const diagnostic_format_string<Args...>& info,
         Args&&... args
     )
     {
@@ -321,7 +336,7 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
     void
     verify(
         const bool condition,
-        diagnostic_info<std::type_identity_t<Args>...> info,
+        diagnostic_format_string<std::type_identity_t<Args>...> info,
         Args&&... args
     )
     {
@@ -372,7 +387,7 @@ namespace SYNTHCLONE_LIB_NAMESPACE {
     constexpr
     void
     verify_unreachable(
-        diagnostic_info<std::type_identity_t<Args>...> info,
+        diagnostic_format_string<std::type_identity_t<Args>...> info,
         Args&&... args
     )
     {


### PR DESCRIPTION
Add plugin and session communication interfaces:
* Add `synthclone::plugin` and `synthclone::plugin_instance` interfaces for plugins to implement.
* Add basic session host interfaces for the application to implement.
* Start exporting the diagnostic format template functionality in `synthclone.util` so it can be used by the session logger.
* "Fix" coverage results by ignoring other errors.
* Add simple tests for new functionality.